### PR TITLE
feat: add site footer with about, terms, and privacy links

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,6 +6,7 @@ import ThemeToggle from "@/components/ThemeToggle";
 import { AudioPlayerProvider } from "@/hooks/useAudioPlayer";
 import AudioPlayer from "@/components/AudioPlayer";
 import GenerationBanner from "@/components/GenerationBanner";
+import Footer from "@/components/Footer";
 
 export const metadata: Metadata = {
   title: "Tech Blog Catchup",
@@ -30,6 +31,7 @@ export default function RootLayout({
             <main className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8 pb-24">
               {children}
             </main>
+            <Footer />
             <AudioPlayer />
           </AudioPlayerProvider>
         </ThemeProvider>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+
+export default function Footer() {
+  return (
+    <footer className="border-t border-gray-800 mt-auto">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+          <p className="text-sm text-gray-500">
+            &copy; {new Date().getFullYear()} Tech Blog Catchup
+          </p>
+          <nav className="flex items-center gap-6">
+            <Link
+              href="/about"
+              className="text-sm text-gray-500 hover:text-gray-300 transition-colors"
+            >
+              About
+            </Link>
+            <Link
+              href="/terms"
+              className="text-sm text-gray-500 hover:text-gray-300 transition-colors"
+            >
+              Terms
+            </Link>
+            <Link
+              href="/privacy"
+              className="text-sm text-gray-500 hover:text-gray-300 transition-colors"
+            >
+              Privacy
+            </Link>
+            <a
+              href="https://github.com/gauravsurtani/tech-blog-catchup"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-gray-500 hover:text-gray-300 transition-colors"
+            >
+              GitHub
+            </a>
+          </nav>
+        </div>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- New `Footer` component with About, Terms, Privacy, and GitHub links
- Copyright notice with dynamic year
- Responsive: stacks on mobile, row on desktop
- Uses standard Tailwind gray-800/gray-500 classes matching the dark theme

Closes #32

## Test plan
- [ ] Footer visible at bottom of all pages
- [ ] Links navigate correctly (About/Terms/Privacy will 404 until #33 lands)
- [ ] GitHub link opens in new tab
- [ ] Footer doesn't overlap AudioPlayer
- [ ] Build passes