### PR TITLE
feat: create static pages for About, Terms of Service, and Privacy Policy

### DIFF
--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,0 +1,104 @@
+export default function AboutPage() {
+  return (
+    <div className="max-w-3xl mx-auto py-8 px-4">
+      <h1 className="text-3xl font-bold text-[var(--color-text-primary)] mb-2">
+        About Tech Blog Catchup
+      </h1>
+      <p className="text-sm text-[var(--color-text-muted)] mb-8">
+        Last updated: February 2026
+      </p>
+
+      <div className="prose prose-invert max-w-none space-y-6 text-[var(--color-text-secondary)]">
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            What is Tech Blog Catchup?
+          </h2>
+          <p>
+            Tech Blog Catchup scrapes 15 of the top tech engineering blogs,
+            extracts their articles, and converts them into NotebookLM-style
+            conversational podcasts featuring two AI hosts. The result is a
+            Spotify-like web player where you can browse, filter, and listen to
+            the latest thinking from companies like Meta, Uber, Airbnb,
+            Cloudflare, Netflix, and more.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            Why?
+          </h2>
+          <p>
+            Engineering blogs are some of the best sources of real-world
+            technical knowledge, but keeping up with all of them is
+            time-consuming. Tech Blog Catchup turns long-form posts into
+            bite-sized audio you can listen to during a commute, workout, or
+            coffee break — so you never fall behind on what top engineering
+            teams are building.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            How it works
+          </h2>
+          <ol className="list-decimal list-inside space-y-2 text-[var(--color-text-secondary)]">
+            <li>
+              <strong className="text-[var(--color-text-primary)]">Discover & Crawl</strong>{" "}
+              — Sitemaps, RSS feeds, and blog page scraping find new posts
+              across all sources.
+            </li>
+            <li>
+              <strong className="text-[var(--color-text-primary)]">Extract & Tag</strong>{" "}
+              — Content is extracted with quality scoring, then auto-tagged into
+              12 categories (infrastructure, AI/ML, security, and more).
+            </li>
+            <li>
+              <strong className="text-[var(--color-text-primary)]">Generate Podcasts</strong>{" "}
+              — An LLM writes a two-host conversational script, then
+              text-to-speech produces the final audio.
+            </li>
+            <li>
+              <strong className="text-[var(--color-text-primary)]">Listen</strong>{" "}
+              — Browse the web player, filter by source or tag, build playlists,
+              and hit play.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            Tech highlights
+          </h2>
+          <ul className="list-disc list-inside space-y-1 text-[var(--color-text-secondary)]">
+            <li>Crawl4AI + RSS + sitemap discovery for broad coverage</li>
+            <li>Multi-strategy content extraction with quality gating</li>
+            <li>OpenAI TTS for natural-sounding conversational audio</li>
+            <li>FastAPI backend with async job tracking</li>
+            <li>Next.js 16 + React 19 frontend with global audio player</li>
+            <li>Deployable via Docker or Railway with persistent storage</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            Built by
+          </h2>
+          <p>
+            Tech Blog Catchup is a personal project by Gaurav Surtani, built to
+            make engineering knowledge more accessible. Contributions and
+            feedback are welcome on{" "}
+            <a
+              href="https://github.com/gauravsurtani/tech-blog-catchup"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[var(--color-accent)] hover:underline"
+            >
+              GitHub
+            </a>
+            .
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -1,0 +1,151 @@
+export default function PrivacyPage() {
+  return (
+    <div className="max-w-3xl mx-auto py-8 px-4">
+      <h1 className="text-3xl font-bold text-[var(--color-text-primary)] mb-2">
+        Privacy Policy
+      </h1>
+      <p className="text-sm text-[var(--color-text-muted)] mb-8">
+        Last updated: February 2026
+      </p>
+
+      <div className="prose prose-invert max-w-none space-y-6 text-[var(--color-text-secondary)]">
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            1. Overview
+          </h2>
+          <p>
+            Tech Blog Catchup is committed to protecting your privacy. This
+            policy explains what data we collect, how we use it, and your rights
+            regarding that data.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            2. Data We Collect
+          </h2>
+          <p>
+            Tech Blog Catchup does not require user accounts and collects
+            minimal data:
+          </p>
+          <ul className="list-disc list-inside space-y-1 text-[var(--color-text-secondary)]">
+            <li>
+              <strong className="text-[var(--color-text-primary)]">
+                No personal information
+              </strong>{" "}
+              — We do not collect names, email addresses, or any
+              personally identifiable information.
+            </li>
+            <li>
+              <strong className="text-[var(--color-text-primary)]">
+                Local storage only
+              </strong>{" "}
+              — Playback preferences (volume, speed, queue) are stored in your
+              browser&apos;s localStorage. This data never leaves your device.
+            </li>
+            <li>
+              <strong className="text-[var(--color-text-primary)]">
+                No analytics tracking
+              </strong>{" "}
+              — We do not use Google Analytics, Facebook Pixel, or any
+              third-party tracking scripts.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            3. Cookies
+          </h2>
+          <p>
+            Tech Blog Catchup does not set cookies. All client-side state is
+            managed through browser localStorage, which is not transmitted to
+            our servers.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            4. Third-Party Services
+          </h2>
+          <p>
+            The Service uses the following third-party services during content
+            processing (server-side only):
+          </p>
+          <ul className="list-disc list-inside space-y-1 text-[var(--color-text-secondary)]">
+            <li>
+              <strong className="text-[var(--color-text-primary)]">
+                OpenAI API
+              </strong>{" "}
+              — For generating podcast scripts and text-to-speech audio. No user
+              data is sent to OpenAI.
+            </li>
+            <li>
+              <strong className="text-[var(--color-text-primary)]">
+                Crawl4AI
+              </strong>{" "}
+              — For scraping publicly available blog content. No user data is
+              involved.
+            </li>
+          </ul>
+          <p>
+            These services process only publicly available blog content, not
+            user data.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            5. Data Retention
+          </h2>
+          <p>
+            Since we do not collect personal data, there is nothing to retain or
+            delete. Blog content and generated audio are stored on our servers
+            for the purpose of providing the Service.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            6. Your Rights
+          </h2>
+          <p>
+            As we do not collect personal data, there are no user profiles to
+            access, modify, or delete. You can clear your localStorage at any
+            time through your browser settings to remove locally stored
+            playback preferences.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            7. Changes to This Policy
+          </h2>
+          <p>
+            We may update this Privacy Policy from time to time. Changes will be
+            reflected by an updated &quot;Last updated&quot; date on this page.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            8. Contact
+          </h2>
+          <p>
+            If you have questions about this Privacy Policy, please open an
+            issue on our{" "}
+            <a
+              href="https://github.com/gauravsurtani/tech-blog-catchup"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[var(--color-accent)] hover:underline"
+            >
+              GitHub repository
+            </a>
+            .
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/terms/page.tsx
+++ b/frontend/src/app/terms/page.tsx
@@ -1,0 +1,130 @@
+export default function TermsPage() {
+  return (
+    <div className="max-w-3xl mx-auto py-8 px-4">
+      <h1 className="text-3xl font-bold text-[var(--color-text-primary)] mb-2">
+        Terms of Service
+      </h1>
+      <p className="text-sm text-[var(--color-text-muted)] mb-8">
+        Last updated: February 2026
+      </p>
+
+      <div className="prose prose-invert max-w-none space-y-6 text-[var(--color-text-secondary)]">
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            1. Acceptance of Terms
+          </h2>
+          <p>
+            By accessing or using Tech Blog Catchup (&quot;the Service&quot;),
+            you agree to be bound by these Terms of Service. If you do not agree
+            to these terms, please do not use the Service.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            2. Description of Service
+          </h2>
+          <p>
+            Tech Blog Catchup aggregates publicly available content from tech
+            engineering blogs and generates AI-produced conversational podcast
+            summaries. The Service is provided for informational and educational
+            purposes.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            3. Content & Intellectual Property
+          </h2>
+          <p>
+            The original blog content referenced by the Service remains the
+            intellectual property of its respective authors and publishers.
+            Podcast audio is generated using AI and represents a summary
+            interpretation, not a reproduction of the original work. We link
+            back to original sources whenever possible.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            4. Use Restrictions
+          </h2>
+          <p>You agree not to:</p>
+          <ul className="list-disc list-inside space-y-1 text-[var(--color-text-secondary)]">
+            <li>
+              Use the Service for any unlawful purpose or in violation of any
+              applicable laws
+            </li>
+            <li>
+              Attempt to interfere with, compromise, or disrupt the Service
+            </li>
+            <li>
+              Redistribute generated audio content for commercial purposes
+              without permission
+            </li>
+            <li>
+              Scrape or programmatically access the Service beyond normal usage
+              patterns
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            5. Disclaimer of Warranties
+          </h2>
+          <p>
+            The Service is provided &quot;as is&quot; and &quot;as
+            available&quot; without warranties of any kind, either express or
+            implied. We do not guarantee the accuracy, completeness, or
+            reliability of any AI-generated content. Podcast summaries may
+            contain errors or omissions — always refer to the original blog post
+            for authoritative information.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            6. Limitation of Liability
+          </h2>
+          <p>
+            To the fullest extent permitted by law, Tech Blog Catchup and its
+            maintainers shall not be liable for any indirect, incidental,
+            special, or consequential damages arising out of your use of the
+            Service.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            7. Changes to Terms
+          </h2>
+          <p>
+            We reserve the right to modify these Terms of Service at any time.
+            Changes will be reflected by an updated &quot;Last updated&quot;
+            date on this page. Continued use of the Service after changes
+            constitutes acceptance of the revised terms.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">
+            8. Contact
+          </h2>
+          <p>
+            If you have questions about these Terms, please open an issue on our{" "}
+            <a
+              href="https://github.com/gauravsurtani/tech-blog-catchup"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[var(--color-accent)] hover:underline"
+            >
+              GitHub repository
+            </a>
+            .
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `/about` page with project description, mission, how-it-works flow, and tech highlights
- `/terms` page with terms of service template (content IP, use restrictions, disclaimers, limitation of liability)
- `/privacy` page with privacy policy (no PII collected, localStorage only, no cookies, no third-party tracking)
- All three pages use consistent layout: `max-w-3xl` container, prose typography, CSS var colors, "Last updated: February 2026"
- Statically prerendered (no API calls, no client-side hooks)

Closes #33

## Test plan
- [ ] `/about` renders with project description and 5 sections
- [ ] `/terms` renders with 8 ToS sections
- [ ] `/privacy` renders with 8 privacy policy sections
- [ ] All pages match dark theme (CSS var colors)
- [ ] GitHub links open in new tab
- [ ] Build passes with new routes (`npm run build` shows /about, /terms, /privacy as static)