### PR TITLE
feat: create design tokens and light/dark theme toggle

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "lucide-react": "^0.563.0",
         "next": "16.1.6",
+        "next-themes": "^0.4.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
@@ -6215,6 +6216,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "lucide-react": "^0.563.0",
     "next": "16.1.6",
+    "next-themes": "^0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -63,6 +63,35 @@
   --z-modal: 70;
 }
 
+/* Light theme overrides */
+html.light {
+  --color-bg-primary: #ffffff;
+  --color-bg-secondary: #f9fafb;     /* gray-50 */
+  --color-bg-tertiary: #f3f4f6;      /* gray-100 */
+  --color-bg-hover: #e5e7eb;         /* gray-200 */
+
+  --color-text-primary: #111827;     /* gray-900 */
+  --color-text-secondary: #4b5563;   /* gray-600 */
+  --color-text-muted: #9ca3af;       /* gray-400 */
+
+  --color-border: #e5e7eb;           /* gray-200 */
+  --color-border-hover: #d1d5db;     /* gray-300 */
+
+  --color-accent: #16a34a;           /* green-600 */
+  --color-accent-hover: #15803d;     /* green-700 */
+  --color-accent-text: #ffffff;
+
+  --color-info: #2563eb;             /* blue-600 */
+  --color-warning: #ca8a04;          /* yellow-600 */
+  --color-error: #dc2626;            /* red-600 */
+
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1);
+
+  --player-bg: var(--color-bg-secondary);
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   background-color: var(--color-bg-primary);

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
+import ThemeProvider from "@/components/ThemeProvider";
+import ThemeToggle from "@/components/ThemeToggle";
 import { AudioPlayerProvider } from "@/hooks/useAudioPlayer";
 import AudioPlayer from "@/components/AudioPlayer";
 
@@ -15,15 +17,20 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="dark">
-      <body className="bg-gray-950 text-gray-100 min-h-screen flex flex-col">
-        <AudioPlayerProvider>
-          <Navbar />
-          <main className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8 pb-24">
-            {children}
-          </main>
-          <AudioPlayer />
-        </AudioPlayerProvider>
+    <html lang="en" suppressHydrationWarning>
+      <body className="bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] min-h-screen flex flex-col">
+        <ThemeProvider>
+          <AudioPlayerProvider>
+            <Navbar />
+            <div className="fixed top-4 right-4 z-50">
+              <ThemeToggle />
+            </div>
+            <main className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8 pb-24">
+              {children}
+            </main>
+            <AudioPlayer />
+          </AudioPlayerProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/src/components/ThemeProvider.tsx
+++ b/frontend/src/components/ThemeProvider.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export default function ThemeProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="dark"
+      enableSystem={false}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Sun, Moon } from "lucide-react";
+import { useSyncExternalStore } from "react";
+
+const emptySubscribe = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const mounted = useSyncExternalStore(
+    emptySubscribe,
+    getClientSnapshot,
+    getServerSnapshot
+  );
+
+  if (!mounted) {
+    return (
+      <button
+        className="p-2 rounded-md bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)]"
+        aria-label="Toggle theme"
+      >
+        <Sun className="w-5 h-5" />
+      </button>
+    );
+  }
+
+  const isDark = theme === "dark";
+
+  return (
+    <button
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className="p-2 rounded-md bg-[var(--color-bg-tertiary)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] transition-colors cursor-pointer"
+      aria-label={isDark ? "Switch to light theme" : "Switch to dark theme"}
+      title={isDark ? "Switch to light theme" : "Switch to dark theme"}
+    >
+      {isDark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Light-mode CSS custom properties added to `globals.css` alongside existing dark vars
- `next-themes` configured with class attribute strategy, default dark theme
- `ThemeProvider` wrapper component handles server/client boundary cleanly
- `ThemeToggle` component with sun/moon icons (lucide-react), hydration-safe via `useSyncExternalStore`
- Body in `layout.tsx` uses CSS vars (`--color-bg-primary`, `--color-text-primary`) instead of hardcoded Tailwind colors

Closes #4

## Test plan
- [ ] Default theme is dark on first visit
- [ ] Click toggle (top-right) switches to light theme
- [ ] Refresh page — theme persists via localStorage
- [ ] All existing components readable in both themes
- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] No hydration mismatch warnings in console