### PR TITLE
feat: horizontal scroll carousel component (#17)

### DIFF
--- a/frontend/src/components/Carousel.tsx
+++ b/frontend/src/components/Carousel.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useRef, useState, useEffect, useCallback, type ReactNode } from "react";
+import Link from "next/link";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface CarouselProps {
+  title: string;
+  seeAllHref?: string;
+  children: ReactNode;
+}
+
+export default function Carousel({ title, seeAllHref, children }: CarouselProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    const observer = new ResizeObserver(updateScrollState);
+    observer.observe(el);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      observer.disconnect();
+    };
+  }, [updateScrollState]);
+
+  function scroll(direction: "left" | "right") {
+    const el = scrollRef.current;
+    if (!el) return;
+    const cardWidth = el.firstElementChild
+      ? el.firstElementChild.getBoundingClientRect().width + 16
+      : 300;
+    const distance = cardWidth * 2;
+    el.scrollBy({
+      left: direction === "left" ? -distance : distance,
+      behavior: "smooth",
+    });
+  }
+
+  return (
+    <section className="relative">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-bold text-gray-100">{title}</h2>
+        {seeAllHref && (
+          <Link
+            href={seeAllHref}
+            className="text-sm text-gray-400 hover:text-white transition-colors"
+          >
+            See all
+          </Link>
+        )}
+      </div>
+
+      {/* Scroll container */}
+      <div className="relative group">
+        {/* Left arrow */}
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll("left")}
+            className="hidden md:flex absolute left-0 top-1/2 -translate-y-1/2 -translate-x-3 z-10 w-9 h-9 items-center justify-center rounded-full bg-gray-800 border border-gray-700 text-gray-300 hover:bg-gray-700 hover:text-white transition-colors shadow-lg cursor-pointer"
+            aria-label="Scroll left"
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </button>
+        )}
+
+        {/* Right arrow */}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll("right")}
+            className="hidden md:flex absolute right-0 top-1/2 -translate-y-1/2 translate-x-3 z-10 w-9 h-9 items-center justify-center rounded-full bg-gray-800 border border-gray-700 text-gray-300 hover:bg-gray-700 hover:text-white transition-colors shadow-lg cursor-pointer"
+            aria-label="Scroll right"
+          >
+            <ChevronRight className="w-5 h-5" />
+          </button>
+        )}
+
+        {/* Cards */}
+        <div
+          ref={scrollRef}
+          className="flex gap-4 overflow-x-auto snap-x snap-mandatory pb-2"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+        >
+          <style jsx>{`
+            div::-webkit-scrollbar {
+              display: none;
+            }
+          `}</style>
+          {children}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/CarouselCard.tsx
+++ b/frontend/src/components/CarouselCard.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import Link from "next/link";
+import { Clock, Radio } from "lucide-react";
+import type { Post } from "@/lib/types";
+
+interface CarouselCardProps {
+  post: Post;
+}
+
+function formatDuration(seconds: number | null): string {
+  if (!seconds) return "";
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  if (mins >= 60) {
+    const hrs = Math.floor(mins / 60);
+    const remainMins = mins % 60;
+    return `${hrs}h ${remainMins}m`;
+  }
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+}
+
+export default function CarouselCard({ post }: CarouselCardProps) {
+  return (
+    <Link
+      href={`/post/${post.id}`}
+      className="flex-shrink-0 w-48 sm:w-56 snap-start bg-gray-900 border border-gray-800 rounded-xl p-4 flex flex-col gap-2.5 hover:border-gray-600 transition-colors group"
+    >
+      {/* Source icon + name */}
+      <div className="flex items-center gap-2">
+        <Radio className="w-3.5 h-3.5 text-gray-500 flex-shrink-0" />
+        <span className="text-xs font-medium text-gray-500 uppercase tracking-wide truncate">
+          {post.source_name}
+        </span>
+      </div>
+
+      {/* Title */}
+      <h3 className="text-sm font-semibold text-gray-200 group-hover:text-white transition-colors line-clamp-2 leading-snug">
+        {post.title}
+      </h3>
+
+      {/* Footer: source + duration */}
+      <div className="mt-auto flex items-center justify-between text-xs text-gray-500">
+        <span className="truncate">{post.source_name}</span>
+        {post.audio_duration_secs ? (
+          <span className="flex items-center gap-1 flex-shrink-0">
+            <Clock className="w-3 h-3" />
+            {formatDuration(post.audio_duration_secs)}
+          </span>
+        ) : null}
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- **Carousel.tsx** — Reusable horizontal scroll container with CSS `scroll-snap-type: x mandatory`, left/right chevron arrows (desktop only, hidden on mobile), hidden scrollbar, ResizeObserver for dynamic arrow visibility
- **CarouselCard.tsx** — Compact podcast card (fixed 48/56 rem width) showing source icon, 2-line clamped title, source name, and audio duration badge; links to `/post/[id]`

Closes #17

## Test plan
- [x] `npm run build` passes with no TypeScript errors
- [ ] Verify carousel scrolls horizontally with mouse/trackpad
- [ ] Verify touch/swipe works on mobile
- [ ] Verify left/right arrows appear on desktop when content overflows
- [ ] Verify arrows hide when at scroll boundary
- [ ] Verify CarouselCard links navigate to post detail page