### PR TITLE
feat: add PWA manifest, service worker, and app icons (#34)

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "Tech Blog Catchup",
+  "short_name": "TBC",
+  "description": "Listen to tech engineering blogs as conversational podcasts",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#030712",
+  "theme_color": "#22c55e",
+  "icons": [
+    { "src": "/favicon.svg", "sizes": "any", "type": "image/svg+xml" },
+    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,45 @@
+const CACHE_NAME = "tbc-v1";
+const STATIC_ASSETS = ["/", "/favicon.svg", "/manifest.json"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Network-first for API calls
+  if (url.pathname.startsWith("/api")) {
+    event.respondWith(
+      fetch(request).catch(() => caches.match(request))
+    );
+    return;
+  }
+
+  // Cache-first for static assets
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      if (cached) return cached;
+      return fetch(request).then((response) => {
+        if (response.ok && request.method === "GET") {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+        }
+        return response;
+      });
+    })
+  );
+});

--- a/frontend/src/app/icon-192.tsx
+++ b/frontend/src/app/icon-192.tsx
@@ -1,0 +1,44 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 192, height: 192 };
+export const contentType = "image/png";
+
+export default function Icon192() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: 192,
+          height: 192,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#030712",
+          borderRadius: 36,
+        }}
+      >
+        <svg
+          viewBox="0 0 32 32"
+          width="140"
+          height="140"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6 18C6 11.373 11.373 6 18 6c5.523 0 10 4.477 10 10v4"
+            stroke="#22c55e"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            fill="none"
+          />
+          <rect x="4" y="17" width="5" height="9" rx="2.5" fill="#22c55e" />
+          <rect x="25" y="17" width="5" height="9" rx="2.5" fill="#22c55e" />
+          <rect x="13" y="19" width="1.5" height="5" rx="0.75" fill="#22c55e" opacity="0.6" />
+          <rect x="16" y="17" width="1.5" height="9" rx="0.75" fill="#22c55e" opacity="0.8" />
+          <rect x="19" y="18" width="1.5" height="7" rx="0.75" fill="#22c55e" opacity="0.6" />
+        </svg>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/frontend/src/app/icon-512.tsx
+++ b/frontend/src/app/icon-512.tsx
@@ -1,0 +1,44 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 512, height: 512 };
+export const contentType = "image/png";
+
+export default function Icon512() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: 512,
+          height: 512,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#030712",
+          borderRadius: 96,
+        }}
+      >
+        <svg
+          viewBox="0 0 32 32"
+          width="380"
+          height="380"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6 18C6 11.373 11.373 6 18 6c5.523 0 10 4.477 10 10v4"
+            stroke="#22c55e"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            fill="none"
+          />
+          <rect x="4" y="17" width="5" height="9" rx="2.5" fill="#22c55e" />
+          <rect x="25" y="17" width="5" height="9" rx="2.5" fill="#22c55e" />
+          <rect x="13" y="19" width="1.5" height="5" rx="0.75" fill="#22c55e" opacity="0.6" />
+          <rect x="16" y="17" width="1.5" height="9" rx="0.75" fill="#22c55e" opacity="0.8" />
+          <rect x="19" y="18" width="1.5" height="7" rx="0.75" fill="#22c55e" opacity="0.6" />
+        </svg>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -11,6 +11,7 @@ import Footer from "@/components/Footer";
 export const metadata: Metadata = {
   title: "Tech Blog Catchup",
   description: "Listen to tech engineering blogs as conversational podcasts",
+  manifest: "/manifest.json",
   icons: {
     icon: [
       { url: "/favicon.svg", type: "image/svg+xml" },


### PR DESCRIPTION
## Summary
- Add `manifest.json` with standalone display mode, dark background, green theme color
- Add `sw.js` service worker: cache-first for static assets, network-first for API calls
- Add `icon-192.tsx` and `icon-512.tsx` using Next.js ImageResponse (same SVG as existing favicon)
- Add `manifest` link in layout.tsx metadata

## Test plan
- [ ] Verify manifest loads in Chrome DevTools > Application > Manifest
- [ ] Verify service worker registers in DevTools > Application > Service Workers
- [ ] Verify icon-192 and icon-512 render at their respective URLs
- [ ] Test install prompt appears on mobile Chrome

Closes #34