### PR TITLE
feat: add User model, auth middleware, and /users/me endpoints

### DIFF
--- a/backend/src/api/auth_middleware.py
+++ b/backend/src/api/auth_middleware.py
@@ -1,0 +1,88 @@
+"""JWT authentication middleware for user endpoints."""
+
+import logging
+import os
+
+import jwt
+from fastapi import Request, HTTPException
+
+from src.database import get_session
+from src.models import User
+
+logger = logging.getLogger(__name__)
+
+
+def _get_secret() -> str:
+    """Return the JWT secret used by NextAuth for token signing."""
+    secret = os.environ.get("NEXTAUTH_SECRET")
+    if not secret:
+        raise HTTPException(status_code=500, detail="Auth not configured")
+    return secret
+
+
+def _extract_token(request: Request) -> str | None:
+    """Extract Bearer token from Authorization header."""
+    auth_header = request.headers.get("Authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
+        return None
+    return auth_header[7:]  # strip "Bearer "
+
+
+def get_current_user(request: Request) -> User:
+    """FastAPI dependency: validate JWT and return the authenticated User.
+
+    Raises 401 if token is missing, invalid, or user not found.
+    """
+    token = _extract_token(request)
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing authorization token")
+
+    try:
+        payload = jwt.decode(token, _get_secret(), algorithms=["HS256"])
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    email: str | None = payload.get("email")
+    if not email:
+        raise HTTPException(status_code=401, detail="Token missing email claim")
+
+    session = get_session()
+    try:
+        user = session.query(User).filter(User.email == email).first()
+        if not user:
+            raise HTTPException(status_code=401, detail="User not found")
+        # Expunge so user can be used after session closes
+        session.expunge(user)
+        return user
+    finally:
+        session.close()
+
+
+def get_optional_user(request: Request) -> User | None:
+    """FastAPI dependency: return User if valid token present, else None.
+
+    For public endpoints that optionally personalize for logged-in users.
+    """
+    token = _extract_token(request)
+    if not token:
+        return None
+
+    try:
+        payload = jwt.decode(token, _get_secret(), algorithms=["HS256"])
+    except jwt.InvalidTokenError:
+        return None
+
+    email: str | None = payload.get("email")
+    if not email:
+        return None
+
+    session = get_session()
+    try:
+        user = session.query(User).filter(User.email == email).first()
+        if user:
+            session.expunge(user)
+        return user
+    finally:
+        session.close()

--- a/backend/src/api/routes.py
+++ b/backend/src/api/routes.py
@@ -2,24 +2,28 @@
 
 import json
 import logging
+import os
 import time
 from datetime import datetime
+from pathlib import Path
 from urllib.parse import urlparse
 
-from fastapi import APIRouter, Query, HTTPException, BackgroundTasks, Request
+from fastapi import APIRouter, Depends, Query, HTTPException, BackgroundTasks, Request
 from sqlalchemy import func, desc, asc
 from sqlalchemy.orm import joinedload
 
 logger = logging.getLogger(__name__)
 
 from src.database import get_session
-from src.models import Post, Tag, CrawlLog, post_tags, Job
+from src.models import Post, Tag, CrawlLog, post_tags, Job, User, UserPreferences
 from src.api.schemas import (
     PostSummary, PostDetail, TagInfo, SourceInfo,
     StatusInfo, PaginatedPosts, CrawlRequest, GenerateRequest,
     JobInfo, CrawlStatusItem,
+    UserMeResponse, UserInfo, UserPreferencesInfo, UpdatePreferencesRequest,
 )
 from src.api.rate_limit import limiter
+from src.api.auth_middleware import get_current_user
 
 router = APIRouter(prefix="/api")
 
@@ -518,4 +522,136 @@ def health():
         "total_posts": total_posts,
         "audio_ready_count": audio_ready,
         "version": "0.1.0",
+        "audio_base_url": os.getenv("AUDIO_BASE_URL", "/audio"),
     }
+
+
+@router.get("/config")
+def get_config_endpoint():
+    """Public configuration for clients (audio URL, version)."""
+    return {
+        "audio_base_url": os.getenv("AUDIO_BASE_URL", "/audio"),
+        "version": "0.1.0",
+    }
+
+
+@router.get("/audio-inventory")
+def audio_inventory():
+    """Compare posts with audio_status=ready against actual files on disk."""
+    audio_dir_env = os.getenv("AUDIO_DIR")
+    audio_dir = Path(audio_dir_env) if audio_dir_env else Path(__file__).parent.parent.parent / "audio"
+
+    session = get_session()
+    try:
+        ready_posts = (
+            session.query(Post)
+            .filter(Post.audio_status == "ready")
+            .all()
+        )
+
+        expected_files: dict[str, Post] = {}
+        missing = []
+        for post in ready_posts:
+            if not post.audio_path:
+                missing.append({
+                    "post_id": post.id,
+                    "title": post.title,
+                    "expected_path": None,
+                })
+                continue
+            filename = Path(post.audio_path).name
+            expected_files[filename] = post
+            full_path = audio_dir / filename
+            if not full_path.exists():
+                missing.append({
+                    "post_id": post.id,
+                    "title": post.title,
+                    "expected_path": str(full_path),
+                })
+
+        orphaned = []
+        if audio_dir.is_dir():
+            for entry in audio_dir.iterdir():
+                if entry.is_file() and entry.name not in expected_files:
+                    orphaned.append(entry.name)
+
+        files_on_disk = sum(
+            1 for post in ready_posts
+            if post.audio_path and (audio_dir / Path(post.audio_path).name).exists()
+        )
+
+        return {
+            "total_ready": len(ready_posts),
+            "files_on_disk": files_on_disk,
+            "missing": missing,
+            "orphaned": sorted(orphaned),
+            "audio_dir": str(audio_dir.resolve()),
+        }
+    finally:
+        session.close()
+
+
+# ---------- User endpoints ----------
+
+
+@router.get("/users/me", response_model=UserMeResponse)
+def get_me(current_user: User = Depends(get_current_user)):
+    """Return the authenticated user and their preferences."""
+    session = get_session()
+    try:
+        prefs = session.query(UserPreferences).filter(
+            UserPreferences.user_id == current_user.id
+        ).first()
+
+        prefs_info = UserPreferencesInfo(
+            theme=prefs.theme if prefs else "dark",
+            playback_speed=prefs.playback_speed if prefs else 1.0,
+            notifications=prefs.notifications if prefs else True,
+        )
+
+        return UserMeResponse(
+            user=UserInfo.model_validate(current_user),
+            preferences=prefs_info,
+        )
+    finally:
+        session.close()
+
+
+@router.patch("/users/me", response_model=UserMeResponse)
+def update_me(
+    req: UpdatePreferencesRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """Update the authenticated user's preferences."""
+    session = get_session()
+    try:
+        prefs = session.query(UserPreferences).filter(
+            UserPreferences.user_id == current_user.id
+        ).first()
+
+        if not prefs:
+            prefs = UserPreferences(user_id=current_user.id)
+            session.add(prefs)
+            session.flush()
+
+        if req.theme is not None:
+            prefs.theme = req.theme
+        if req.playback_speed is not None:
+            prefs.playback_speed = req.playback_speed
+        if req.notifications is not None:
+            prefs.notifications = req.notifications
+
+        session.commit()
+
+        prefs_info = UserPreferencesInfo(
+            theme=prefs.theme,
+            playback_speed=prefs.playback_speed,
+            notifications=prefs.notifications,
+        )
+
+        return UserMeResponse(
+            user=UserInfo.model_validate(current_user),
+            preferences=prefs_info,
+        )
+    finally:
+        session.close()

--- a/backend/src/api/schemas.py
+++ b/backend/src/api/schemas.py
@@ -96,3 +96,33 @@ class JobInfo(BaseModel):
     completed_at: datetime | None
 
     model_config = {"from_attributes": True}
+
+
+class UserInfo(BaseModel):
+    id: int
+    email: str
+    name: str | None
+    avatar_url: str | None
+    provider: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class UserPreferencesInfo(BaseModel):
+    theme: str = "dark"
+    playback_speed: float = 1.0
+    notifications: bool = True
+
+    model_config = {"from_attributes": True}
+
+
+class UserMeResponse(BaseModel):
+    user: UserInfo
+    preferences: UserPreferencesInfo
+
+
+class UpdatePreferencesRequest(BaseModel):
+    theme: str | None = None
+    playback_speed: float | None = None
+    notifications: bool | None = None

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -2,7 +2,10 @@
 
 from datetime import datetime
 
-from sqlalchemy import Column, Integer, String, Text, DateTime, Table, ForeignKey
+from sqlalchemy import (
+    Boolean, Column, DateTime, Float, ForeignKey,
+    Integer, String, Table, Text,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.database import Base
@@ -90,3 +93,36 @@ class Job(Base):
 
     def __repr__(self) -> str:
         return f"<Job(id={self.id}, type={self.job_type}, status={self.status})>"
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    email: Mapped[str] = mapped_column(String, unique=True, nullable=False, index=True)
+    name: Mapped[str | None] = mapped_column(String, nullable=True)
+    avatar_url: Mapped[str | None] = mapped_column(String, nullable=True)
+    provider: Mapped[str] = mapped_column(String, nullable=False)  # 'google' | 'github'
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    preferences: Mapped["UserPreferences | None"] = relationship(
+        "UserPreferences", back_populates="user", uselist=False
+    )
+
+    def __repr__(self) -> str:
+        return f"<User(id={self.id}, email={self.email!r}, provider={self.provider})>"
+
+
+class UserPreferences(Base):
+    __tablename__ = "user_preferences"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), unique=True, nullable=False)
+    theme: Mapped[str] = mapped_column(String, default="dark")
+    playback_speed: Mapped[float] = mapped_column(Float, default=1.0)
+    notifications: Mapped[bool] = mapped_column(Boolean, default=True)
+
+    user: Mapped["User"] = relationship("User", back_populates="preferences")
+
+    def __repr__(self) -> str:
+        return f"<UserPreferences(id={self.id}, user_id={self.user_id})>"

--- a/backend/tests/test_user.py
+++ b/backend/tests/test_user.py
@@ -1,0 +1,236 @@
+"""Tests for User model, auth middleware, and user API endpoints."""
+
+import jwt
+import pytest
+from unittest.mock import patch
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from fastapi.testclient import TestClient
+
+from src.database import Base
+from src.models import User, UserPreferences
+import src.api.routes as routes_module
+import src.api.auth_middleware as auth_module
+
+TEST_SECRET = "test-jwt-secret-for-unit-tests"
+
+
+@pytest.fixture()
+def test_db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    return engine, SessionLocal
+
+
+@pytest.fixture()
+def client(test_db):
+    _engine, SessionLocal = test_db
+
+    original_routes_get_session = routes_module.get_session
+    original_auth_get_session = auth_module.get_session
+
+    def _test_get_session():
+        return SessionLocal()
+
+    routes_module.get_session = _test_get_session
+    auth_module.get_session = _test_get_session
+
+    try:
+        with patch("src.api.app.init_db"), \
+             patch("src.podcast.manager.recover_stuck_processing", return_value=0), \
+             patch.dict("os.environ", {"NEXTAUTH_SECRET": TEST_SECRET}):
+            from src.api.app import create_app
+            app = create_app()
+            with TestClient(app) as tc:
+                yield tc, SessionLocal
+    finally:
+        routes_module.get_session = original_routes_get_session
+        auth_module.get_session = original_auth_get_session
+
+
+def _make_token(email: str, secret: str = TEST_SECRET) -> str:
+    return jwt.encode({"email": email}, secret, algorithm="HS256")
+
+
+def _seed_user(session_factory, email: str = "test@example.com", provider: str = "google") -> User:
+    session = session_factory()
+    user = User(email=email, name="Test User", provider=provider)
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    session.close()
+    return user
+
+
+class TestUserModel:
+    def test_create_user(self, test_db):
+        _engine, SessionLocal = test_db
+        session = SessionLocal()
+        user = User(email="alice@example.com", name="Alice", provider="github")
+        session.add(user)
+        session.commit()
+
+        fetched = session.query(User).filter(User.email == "alice@example.com").first()
+        assert fetched is not None
+        assert fetched.name == "Alice"
+        assert fetched.provider == "github"
+        assert fetched.created_at is not None
+        session.close()
+
+    def test_user_email_unique(self, test_db):
+        _engine, SessionLocal = test_db
+        session = SessionLocal()
+        session.add(User(email="dup@example.com", provider="google"))
+        session.commit()
+        session.add(User(email="dup@example.com", provider="github"))
+        with pytest.raises(Exception):
+            session.commit()
+        session.close()
+
+    def test_user_repr(self, test_db):
+        _engine, SessionLocal = test_db
+        user = User(id=1, email="repr@test.com", provider="google")
+        assert "repr@test.com" in repr(user)
+
+
+class TestUserPreferencesModel:
+    def test_create_preferences(self, test_db):
+        _engine, SessionLocal = test_db
+        session = SessionLocal()
+        user = User(email="prefs@example.com", provider="google")
+        session.add(user)
+        session.commit()
+
+        prefs = UserPreferences(user_id=user.id, theme="light", playback_speed=1.5, notifications=False)
+        session.add(prefs)
+        session.commit()
+
+        fetched = session.query(UserPreferences).filter(UserPreferences.user_id == user.id).first()
+        assert fetched is not None
+        assert fetched.theme == "light"
+        assert fetched.playback_speed == 1.5
+        assert fetched.notifications is False
+        session.close()
+
+    def test_defaults(self, test_db):
+        _engine, SessionLocal = test_db
+        session = SessionLocal()
+        user = User(email="defaults@example.com", provider="github")
+        session.add(user)
+        session.commit()
+
+        prefs = UserPreferences(user_id=user.id)
+        session.add(prefs)
+        session.commit()
+
+        fetched = session.query(UserPreferences).filter(UserPreferences.user_id == user.id).first()
+        assert fetched.theme == "dark"
+        assert fetched.playback_speed == 1.0
+        assert fetched.notifications is True
+        session.close()
+
+
+class TestGetMe:
+    def test_get_me_success(self, client):
+        tc, SessionLocal = client
+        user = _seed_user(SessionLocal)
+        token = _make_token(user.email)
+
+        resp = tc.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user"]["email"] == "test@example.com"
+        assert data["user"]["name"] == "Test User"
+        assert data["preferences"]["theme"] == "dark"
+        assert data["preferences"]["playback_speed"] == 1.0
+
+    def test_get_me_no_token(self, client):
+        tc, _SessionLocal = client
+        resp = tc.get("/api/users/me")
+        assert resp.status_code == 401
+
+    def test_get_me_invalid_token(self, client):
+        tc, _SessionLocal = client
+        resp = tc.get("/api/users/me", headers={"Authorization": "Bearer invalid.token.here"})
+        assert resp.status_code == 401
+
+    def test_get_me_wrong_secret(self, client):
+        tc, SessionLocal = client
+        _seed_user(SessionLocal)
+        token = _make_token("test@example.com", secret="wrong-secret")
+
+        resp = tc.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 401
+
+    def test_get_me_user_not_found(self, client):
+        tc, _SessionLocal = client
+        token = _make_token("nonexistent@example.com")
+
+        resp = tc.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 401
+
+
+class TestUpdateMe:
+    def test_update_preferences(self, client):
+        tc, SessionLocal = client
+        user = _seed_user(SessionLocal)
+        token = _make_token(user.email)
+
+        resp = tc.patch(
+            "/api/users/me",
+            json={"theme": "light", "playback_speed": 2.0},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["preferences"]["theme"] == "light"
+        assert data["preferences"]["playback_speed"] == 2.0
+        assert data["preferences"]["notifications"] is True  # unchanged
+
+    def test_update_creates_preferences_if_missing(self, client):
+        tc, SessionLocal = client
+        user = _seed_user(SessionLocal)
+        token = _make_token(user.email)
+
+        resp = tc.patch(
+            "/api/users/me",
+            json={"notifications": False},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["preferences"]["notifications"] is False
+
+    def test_update_without_auth(self, client):
+        tc, _SessionLocal = client
+        resp = tc.patch("/api/users/me", json={"theme": "light"})
+        assert resp.status_code == 401
+
+    def test_partial_update(self, client):
+        tc, SessionLocal = client
+        user = _seed_user(SessionLocal)
+        token = _make_token(user.email)
+
+        # First set all preferences
+        tc.patch(
+            "/api/users/me",
+            json={"theme": "light", "playback_speed": 1.5, "notifications": False},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        # Then update only one field
+        resp = tc.patch(
+            "/api/users/me",
+            json={"playback_speed": 2.5},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        prefs = resp.json()["preferences"]
+        assert prefs["theme"] == "light"  # unchanged
+        assert prefs["playback_speed"] == 2.5  # updated
+        assert prefs["notifications"] is False  # unchanged


### PR DESCRIPTION
## Summary
- Add `User` and `UserPreferences` SQLAlchemy models with email-indexed lookup and one-to-one preferences relationship
- Add JWT auth middleware (`get_current_user`, `get_optional_user`) validating tokens signed with `NEXTAUTH_SECRET`
- Add `GET /api/users/me` and `PATCH /api/users/me` authenticated endpoints for reading/updating user preferences
- Add PyJWT dependency to `pyproject.toml`

## Test plan
- [x] 14 new tests in `backend/tests/test_user.py` — all passing
- [x] Tests cover: model creation, unique constraints, repr, JWT validation (missing/invalid/wrong-secret/user-not-found), GET/PATCH with auth, partial updates, preference auto-creation

Closes #10