### PR TITLE
feat: collapsible sidebar navigation (#13)

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,21 +1,38 @@
 import type { Metadata } from "next";
+import { Inter } from "next/font/google";
 import "./globals.css";
-import Navbar from "@/components/Navbar";
+import Sidebar from "@/components/Sidebar";
+import SidebarLayout from "@/components/SidebarLayout";
 import ThemeProvider from "@/components/ThemeProvider";
 import ThemeToggle from "@/components/ThemeToggle";
 import { AudioPlayerProvider } from "@/hooks/useAudioPlayer";
 import AudioPlayer from "@/components/AudioPlayer";
 import GenerationBanner from "@/components/GenerationBanner";
 import Footer from "@/components/Footer";
+import SessionProvider from "@/components/SessionProvider";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
 export const metadata: Metadata = {
-  title: "Tech Blog Catchup",
+  title: {
+    default: "Tech Blog Catchup",
+    template: "%s | Tech Blog Catchup",
+  },
   description: "Listen to tech engineering blogs as conversational podcasts",
   manifest: "/manifest.json",
+  openGraph: {
+    type: "website",
+    siteName: "Tech Blog Catchup",
+    title: "Tech Blog Catchup",
+    description: "Listen to tech engineering blogs as conversational podcasts",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Tech Blog Catchup",
+    description: "Listen to tech engineering blogs as conversational podcasts",
+  },
   icons: {
-    icon: [
-      { url: "/favicon.svg", type: "image/svg+xml" },
-    ],
+    icon: [{ url: "/favicon.svg", type: "image/svg+xml" }],
   },
 };
 
@@ -26,20 +43,24 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className="bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] min-h-screen flex flex-col">
+      <body className={`${inter.variable} bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] min-h-screen`}>
         <ThemeProvider>
-          <AudioPlayerProvider>
-            <Navbar />
-            <GenerationBanner />
-            <div className="fixed top-4 right-4 z-50">
-              <ThemeToggle />
-            </div>
-            <main className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8 pb-24">
-              {children}
-            </main>
-            <Footer />
-            <AudioPlayer />
-          </AudioPlayerProvider>
+          <SessionProvider>
+            <AudioPlayerProvider>
+              <Sidebar />
+              <SidebarLayout>
+                <GenerationBanner />
+                <div className="fixed top-4 right-4 z-50">
+                  <ThemeToggle />
+                </div>
+                <main className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8 pb-24">
+                  {children}
+                </main>
+                <Footer />
+              </SidebarLayout>
+              <AudioPlayer />
+            </AudioPlayerProvider>
+          </SessionProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useState, useEffect } from "react";
+import {
+  Home,
+  Compass,
+  Library,
+  ListMusic,
+  BarChart3,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
+import Logo from "./Logo";
+
+const STORAGE_KEY = "sidebar-collapsed";
+
+const navItems = [
+  { href: "/", label: "Home", icon: Home },
+  { href: "/explore", label: "Explore", icon: Compass },
+  { href: "/library", label: "Library", icon: Library },
+  { href: "/playlist", label: "Playlist", icon: ListMusic },
+  { href: "/status", label: "Status", icon: BarChart3 },
+];
+
+export default function Sidebar() {
+  const pathname = usePathname();
+  const [collapsed, setCollapsed] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "true") setCollapsed(true);
+    setMounted(true);
+  }, []);
+
+  const toggle = () => {
+    const next = !collapsed;
+    setCollapsed(next);
+    localStorage.setItem(STORAGE_KEY, String(next));
+    window.dispatchEvent(new Event("sidebar-toggle"));
+  };
+
+  return (
+    <aside
+      className="hidden md:flex flex-col fixed top-0 left-0 h-screen border-r border-[var(--color-border)] bg-[var(--color-bg-secondary)] transition-[width] duration-300 ease-in-out"
+      style={{
+        width: mounted ? (collapsed ? 72 : 240) : 240,
+        zIndex: "var(--z-nav)",
+      }}
+    >
+      {/* Logo */}
+      <div className="flex items-center h-16 px-4 border-b border-[var(--color-border)]">
+        <Link href="/" className="text-[var(--color-text-primary)] text-xl">
+          <Logo
+            variant={collapsed ? "icon" : "full"}
+            className={collapsed ? "h-8 w-8" : "text-xl"}
+          />
+        </Link>
+      </div>
+
+      {/* Nav items */}
+      <nav className="flex-1 py-4 flex flex-col gap-1 px-3 overflow-y-auto">
+        {navItems.map(({ href, label, icon: Icon }) => {
+          const active = href === "/" ? pathname === "/" : pathname.startsWith(href);
+          return (
+            <Link
+              key={href}
+              href={href}
+              title={collapsed ? label : undefined}
+              className={`flex items-center gap-3 rounded-[var(--radius-md)] px-3 py-2.5 text-sm font-medium transition-colors ${
+                active
+                  ? "bg-[var(--color-accent)] text-[var(--color-accent-text)]"
+                  : "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)]"
+              }`}
+            >
+              <Icon size={20} className="shrink-0" />
+              {!collapsed && <span className="whitespace-nowrap">{label}</span>}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* Collapse toggle */}
+      <button
+        onClick={toggle}
+        className="flex items-center justify-center h-12 border-t border-[var(--color-border)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
+        aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+      >
+        {collapsed ? <ChevronRight size={18} /> : <ChevronLeft size={18} />}
+      </button>
+    </aside>
+  );
+}
+
+/** CSS class for main content margin. Use in layout.tsx. */
+export const SIDEBAR_EXPANDED_WIDTH = 240;
+export const SIDEBAR_COLLAPSED_WIDTH = 72;

--- a/frontend/src/components/SidebarLayout.tsx
+++ b/frontend/src/components/SidebarLayout.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+const STORAGE_KEY = "sidebar-collapsed";
+const MD_BREAKPOINT = 768;
+
+/**
+ * Wrapper that shifts main content to account for sidebar width on desktop.
+ * On mobile (< md), no margin is applied since sidebar is hidden.
+ */
+export default function SidebarLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [collapsed, setCollapsed] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "true") setCollapsed(true);
+
+    const mq = window.matchMedia(`(min-width: ${MD_BREAKPOINT}px)`);
+    setIsDesktop(mq.matches);
+    const onMq = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+    mq.addEventListener("change", onMq);
+
+    const onSidebarToggle = () => {
+      setCollapsed(localStorage.getItem(STORAGE_KEY) === "true");
+    };
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) {
+        setCollapsed(e.newValue === "true");
+      }
+    };
+
+    window.addEventListener("storage", onStorage);
+    window.addEventListener("sidebar-toggle", onSidebarToggle);
+    return () => {
+      mq.removeEventListener("change", onMq);
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener("sidebar-toggle", onSidebarToggle);
+    };
+  }, []);
+
+  const marginLeft = isDesktop ? (collapsed ? 72 : 240) : 0;
+
+  return (
+    <div
+      className="flex flex-col min-h-screen transition-[margin-left] duration-300 ease-in-out"
+      style={{ marginLeft: `${marginLeft}px` }}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces top `Navbar` with a collapsible left `Sidebar` (240px expanded / 72px collapsed)
- Nav items: Home, Explore, Library, Playlist, Status with Lucide icons and active-state highlight
- Collapse state persists in localStorage; hidden on mobile (< md breakpoint)
- `SidebarLayout` wrapper shifts main content with smooth CSS transition, synced via custom DOM event

## Files Changed
- `frontend/src/components/Sidebar.tsx` (new) — collapsible sidebar component
- `frontend/src/components/SidebarLayout.tsx` (new) — responsive margin wrapper
- `frontend/src/app/layout.tsx` — swapped Navbar for Sidebar + SidebarLayout

## Test plan
- [ ] Desktop: sidebar visible at 240px, collapses to 72px on toggle
- [ ] Collapse state persists across page reload
- [ ] Mobile (< 768px): sidebar hidden, content full-width
- [ ] Active nav item highlighted with accent color
- [ ] Logo switches between full and icon variants
- [ ] Build passes: `npm run build`