### PR TITLE
feat: add bottom tab navigation for mobile

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -8,6 +8,7 @@ import ThemeToggle from "@/components/ThemeToggle";
 import { AudioPlayerProvider } from "@/hooks/useAudioPlayer";
 import AudioPlayer from "@/components/AudioPlayer";
 import GenerationBanner from "@/components/GenerationBanner";
+import BottomTabs from "@/components/BottomTabs";
 import Footer from "@/components/Footer";
 import SessionProvider from "@/components/SessionProvider";
 
@@ -58,6 +59,7 @@ export default function RootLayout({
                 </main>
                 <Footer />
               </SidebarLayout>
+              <BottomTabs />
               <AudioPlayer />
             </AudioPlayerProvider>
           </SessionProvider>

--- a/frontend/src/components/BottomTabs.tsx
+++ b/frontend/src/components/BottomTabs.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Home, Compass, Library, ListMusic, BarChart3 } from "lucide-react";
+
+const tabs = [
+  { href: "/", label: "Home", icon: Home },
+  { href: "/explore", label: "Explore", icon: Compass },
+  { href: "/library", label: "Library", icon: Library },
+  { href: "/playlist", label: "Playlist", icon: ListMusic },
+  { href: "/status", label: "Status", icon: BarChart3 },
+];
+
+export default function BottomTabs() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      className="fixed left-0 right-0 flex md:hidden items-center justify-around border-t border-[var(--color-border)] bg-[var(--color-bg-secondary)]"
+      style={{
+        bottom: "var(--player-height)",
+        zIndex: "var(--z-nav)",
+        height: "3.5rem",
+      }}
+    >
+      {tabs.map(({ href, label, icon: Icon }) => {
+        const active = href === "/" ? pathname === "/" : pathname.startsWith(href);
+        return (
+          <Link
+            key={href}
+            href={href}
+            className={`flex flex-col items-center justify-center flex-1 h-full gap-0.5 text-[10px] font-medium transition-colors ${
+              active
+                ? "text-[var(--color-accent)]"
+                : "text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+            }`}
+          >
+            <Icon size={20} />
+            <span>{label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- New `BottomTabs` component with 5 tabs matching Sidebar icons (Home, Explore, Library, Playlist, Status)
- Mobile-only (`md:hidden`), fixed above AudioPlayer using `--player-height` CSS var
- Active tab highlighted with `--color-accent`

## Test plan
- [ ] Verify tabs visible on mobile viewport, hidden on md+
- [ ] Verify Sidebar hidden on mobile, visible on md+
- [ ] Verify active tab highlights correctly on each route
- [ ] Verify tabs do not overlap AudioPlayer

Closes #14