### PR TITLE
feat: add user avatar dropdown in sidebar (#15)

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   ChevronRight,
 } from "lucide-react";
 import Logo from "./Logo";
+import UserMenu from "./UserMenu";
 
 const STORAGE_KEY = "sidebar-collapsed";
 
@@ -81,6 +82,11 @@ export default function Sidebar() {
           );
         })}
       </nav>
+
+      {/* User menu */}
+      <div className="px-3 py-2 border-t border-[var(--color-border)]">
+        <UserMenu collapsed={collapsed} />
+      </div>
 
       {/* Collapse toggle */}
       <button

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useSession, signOut } from "next-auth/react";
+import Image from "next/image";
+import Link from "next/link";
+import { useState, useRef, useEffect } from "react";
+import { Settings, User, LogOut, LogIn } from "lucide-react";
+
+interface UserMenuProps {
+  collapsed?: boolean;
+}
+
+export default function UserMenu({ collapsed = false }: UserMenuProps) {
+  const { data: session } = useSession();
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  if (!session?.user) {
+    return (
+      <Link
+        href="/login"
+        className="flex items-center gap-3 px-3 py-2.5 text-sm font-medium text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] rounded-[var(--radius-md)] transition-colors"
+        title={collapsed ? "Sign In" : undefined}
+      >
+        <LogIn size={20} className="shrink-0" />
+        {!collapsed && <span className="whitespace-nowrap">Sign In</span>}
+      </Link>
+    );
+  }
+
+  const { user } = session;
+  const initials = (user.name || user.email || "?")
+    .split(" ")
+    .map((w) => w[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+
+  return (
+    <div ref={menuRef} className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-3 w-full px-3 py-2.5 rounded-[var(--radius-md)] text-sm font-medium text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] transition-colors"
+        title={collapsed ? user.name || "Account" : undefined}
+        aria-label="User menu"
+      >
+        {user.image ? (
+          <Image
+            src={user.image}
+            alt={user.name || "User avatar"}
+            width={28}
+            height={28}
+            className="rounded-full shrink-0 object-cover"
+            referrerPolicy="no-referrer"
+            unoptimized
+          />
+        ) : (
+          <span className="w-7 h-7 rounded-full shrink-0 bg-[var(--color-accent)] text-[var(--color-accent-text)] flex items-center justify-center text-xs font-bold">
+            {initials}
+          </span>
+        )}
+        {!collapsed && (
+          <span className="truncate">{user.name || user.email}</span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute bottom-full left-0 mb-2 w-48 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-bg-secondary)] shadow-lg py-1 z-50">
+          <Link
+            href="/profile"
+            onClick={() => setOpen(false)}
+            className="flex items-center gap-2 px-3 py-2 text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] transition-colors"
+          >
+            <User size={16} />
+            Profile
+          </Link>
+          <Link
+            href="/settings"
+            onClick={() => setOpen(false)}
+            className="flex items-center gap-2 px-3 py-2 text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] transition-colors"
+          >
+            <Settings size={16} />
+            Settings
+          </Link>
+          <div className="border-t border-[var(--color-border)] my-1" />
+          <button
+            onClick={() => signOut()}
+            className="flex items-center gap-2 w-full px-3 py-2 text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] transition-colors"
+          >
+            <LogOut size={16} />
+            Sign Out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `UserMenu` component at bottom of sidebar with session-aware avatar display
- Logged-in users see their avatar (or initials fallback) with a dropdown containing Profile, Settings, and Sign Out
- Logged-out users see a "Sign In" link to `/login`
- Dropdown opens upward from sidebar bottom, closes on outside click
- Respects sidebar collapsed/expanded state

## Test plan
- [ ] Verify "Sign In" link appears when not authenticated
- [ ] Verify user avatar and name appear when logged in via Google/GitHub
- [ ] Verify dropdown opens with Profile, Settings, Sign Out links
- [ ] Verify dropdown closes on outside click
- [ ] Verify collapsed sidebar shows icon-only avatar with tooltip
- [ ] Verify Sign Out calls next-auth signOut()

Closes #15