### PR TITLE
feat: add global search dialog with Cmd+K shortcut

### DIFF
--- a/frontend/src/components/SearchDialog.tsx
+++ b/frontend/src/components/SearchDialog.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { Search, X, Loader2 } from "lucide-react";
+import { getPosts } from "@/lib/api";
+import type { Post } from "@/lib/types";
+
+interface SearchDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function SearchDialog({ open, onClose }: SearchDialogProps) {
+  const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setResults([]);
+      setSelectedIndex(0);
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!query.trim()) {
+      setResults([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    const timer = setTimeout(async () => {
+      try {
+        const data = await getPosts({ search: query.trim(), limit: 8 });
+        setResults(data.posts);
+        setSelectedIndex(0);
+      } catch {
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  const navigateToResult = useCallback(
+    (post: Post) => {
+      onClose();
+      router.push(`/post/${post.id}`);
+    },
+    [onClose, router],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter" && results[selectedIndex]) {
+        e.preventDefault();
+        navigateToResult(results[selectedIndex]);
+      }
+    },
+    [results, selectedIndex, navigateToResult],
+  );
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-start justify-center pt-[15vh]"
+      onClick={onClose}
+    >
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+      <div
+        className="relative w-full max-w-lg mx-4 bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-[var(--radius-lg)] shadow-2xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 px-4 border-b border-[var(--color-border)]">
+          <Search size={18} className="shrink-0 text-[var(--color-text-muted)]" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Search posts..."
+            className="flex-1 py-3.5 bg-transparent text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] outline-none text-sm"
+          />
+          {loading && (
+            <Loader2 size={16} className="shrink-0 text-[var(--color-text-muted)] animate-spin" />
+          )}
+          <button
+            onClick={onClose}
+            className="shrink-0 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
+          >
+            <X size={16} />
+          </button>
+        </div>
+        {results.length > 0 && (
+          <ul className="max-h-80 overflow-y-auto py-2">
+            {results.map((post, i) => (
+              <li key={post.id}>
+                <button
+                  onClick={() => navigateToResult(post)}
+                  onMouseEnter={() => setSelectedIndex(i)}
+                  className={`w-full text-left px-4 py-2.5 flex flex-col gap-0.5 transition-colors ${
+                    i === selectedIndex
+                      ? "bg-[var(--color-accent)] text-[var(--color-accent-text)]"
+                      : "text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)]"
+                  }`}
+                >
+                  <span className="text-sm font-medium line-clamp-1">{post.title}</span>
+                  <span
+                    className={`text-xs ${
+                      i === selectedIndex
+                        ? "text-[var(--color-accent-text)]/70"
+                        : "text-[var(--color-text-muted)]"
+                    }`}
+                  >
+                    {post.source_name}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        {query.trim() && !loading && results.length === 0 && (
+          <div className="px-4 py-8 text-center text-sm text-[var(--color-text-muted)]">
+            No posts found for &ldquo;{query}&rdquo;
+          </div>
+        )}
+        <div className="px-4 py-2 border-t border-[var(--color-border)] flex items-center gap-4 text-xs text-[var(--color-text-muted)]">
+          <span><kbd className="px-1.5 py-0.5 bg-[var(--color-bg-hover)] rounded text-[10px] font-mono">Esc</kbd> to close</span>
+          <span><kbd className="px-1.5 py-0.5 bg-[var(--color-bg-hover)] rounded text-[10px] font-mono">&uarr;&darr;</kbd> to navigate</span>
+          <span><kbd className="px-1.5 py-0.5 bg-[var(--color-bg-hover)] rounded text-[10px] font-mono">Enter</kbd> to open</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   Home,
   Compass,
@@ -12,9 +12,11 @@ import {
   BarChart3,
   ChevronLeft,
   ChevronRight,
+  Search,
 } from "lucide-react";
 import Logo from "./Logo";
 import UserMenu from "./UserMenu";
+import SearchDialog from "./SearchDialog";
 
 const STORAGE_KEY = "sidebar-collapsed";
 
@@ -31,12 +33,28 @@ export default function Sidebar() {
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);
   const [mounted, setMounted] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
 
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored === "true") setCollapsed(true);
     setMounted(true);
   }, []);
+
+  const handleGlobalKeyDown = useCallback((e: KeyboardEvent) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+      e.preventDefault();
+      setSearchOpen((prev) => !prev);
+    }
+    if (e.key === "Escape") {
+      setSearchOpen(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleGlobalKeyDown);
+    return () => document.removeEventListener("keydown", handleGlobalKeyDown);
+  }, [handleGlobalKeyDown]);
 
   const toggle = () => {
     const next = !collapsed;
@@ -61,6 +79,28 @@ export default function Sidebar() {
             className={collapsed ? "h-8 w-8" : "text-xl"}
           />
         </Link>
+      </div>
+
+      {/* Search button */}
+      <div className="px-3 pt-4 pb-1">
+        <button
+          onClick={() => setSearchOpen(true)}
+          title={collapsed ? "Search (Cmd+K)" : undefined}
+          className="flex items-center gap-3 w-full rounded-[var(--radius-md)] px-3 py-2.5 text-sm font-medium text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] transition-colors"
+        >
+          <Search size={20} className="shrink-0" />
+          {!collapsed && (
+            <>
+              <span className="flex-1 text-left whitespace-nowrap">Search</span>
+              <kbd className="text-[10px] font-mono text-[var(--color-text-muted)] bg-[var(--color-bg-hover)] px-1.5 py-0.5 rounded">
+                {typeof navigator !== "undefined" && /Mac/.test(navigator.platform)
+                  ? "\u2318"
+                  : "Ctrl+"}
+                K
+              </kbd>
+            </>
+          )}
+        </button>
       </div>
 
       {/* Nav items */}
@@ -98,6 +138,8 @@ export default function Sidebar() {
       >
         {collapsed ? <ChevronRight size={18} /> : <ChevronLeft size={18} />}
       </button>
+
+      <SearchDialog open={searchOpen} onClose={() => setSearchOpen(false)} />
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `SearchDialog` component: modal overlay triggered by **Cmd+K** (Mac) / **Ctrl+K** (other), debounced search against `/api/posts?search=...`, keyboard navigation (arrows + Enter), click to navigate to `/post/[id]`
- Adds search icon button in Sidebar with platform-aware shortcut hint
- Escape closes the dialog

## Test plan
- [ ] Press Cmd+K (or Ctrl+K) — search dialog opens
- [ ] Type a query — results appear after 300ms debounce
- [ ] Arrow keys navigate results, Enter opens selected post
- [ ] Click a result — navigates to post detail page
- [ ] Press Escape — dialog closes
- [ ] Click backdrop — dialog closes
- [ ] Sidebar search button opens dialog
- [ ] Collapsed sidebar shows search icon with tooltip

Closes #26