### PR TITLE
feat: add waveform visualization to progress bar

### DIFF
--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -14,6 +14,7 @@ import {
 import { useAudioPlayer } from "@/hooks/useAudioPlayer";
 import PlaylistQueue from "./PlaylistQueue";
 import FullScreenPlayer from "./FullScreenPlayer";
+import WaveformBar from "./WaveformBar";
 
 function formatTime(seconds: number): string {
   if (!seconds || !isFinite(seconds)) return "0:00";
@@ -42,46 +43,8 @@ export default function AudioPlayer() {
   } = useAudioPlayer();
 
   const [queueOpen, setQueueOpen] = useState(false);
-  const [isDragging, setIsDragging] = useState(false);
-  const progressBarRef = useRef<HTMLDivElement>(null);
   const volumeBarRef = useRef<HTMLDivElement>(null);
   const prevVolumeRef = useRef(volume || 0.75);
-
-  const handleProgressClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      const bar = progressBarRef.current;
-      if (!bar) return;
-      const rect = bar.getBoundingClientRect();
-      const fraction = (e.clientX - rect.left) / rect.width;
-      seek(fraction);
-    },
-    [seek]
-  );
-
-  const handleProgressMouseDown = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      setIsDragging(true);
-      handleProgressClick(e);
-
-      const handleMouseMove = (ev: MouseEvent) => {
-        const bar = progressBarRef.current;
-        if (!bar) return;
-        const rect = bar.getBoundingClientRect();
-        const fraction = (ev.clientX - rect.left) / rect.width;
-        seek(Math.max(0, Math.min(1, fraction)));
-      };
-
-      const handleMouseUp = () => {
-        setIsDragging(false);
-        document.removeEventListener("mousemove", handleMouseMove);
-        document.removeEventListener("mouseup", handleMouseUp);
-      };
-
-      document.addEventListener("mousemove", handleMouseMove);
-      document.addEventListener("mouseup", handleMouseUp);
-    },
-    [handleProgressClick, seek]
-  );
 
   const handleVolumeClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -91,7 +54,7 @@ export default function AudioPlayer() {
       const fraction = (e.clientX - rect.left) / rect.width;
       setVolume(Math.max(0, Math.min(1, fraction)));
     },
-    [setVolume]
+    [setVolume],
   );
 
   const handleVolumeMouseDown = useCallback(
@@ -114,7 +77,7 @@ export default function AudioPlayer() {
       document.addEventListener("mousemove", handleMouseMove);
       document.addEventListener("mouseup", handleMouseUp);
     },
-    [handleVolumeClick, setVolume]
+    [handleVolumeClick, setVolume],
   );
 
   const toggleMute = useCallback(() => {
@@ -161,7 +124,11 @@ export default function AudioPlayer() {
               className="bg-white text-black rounded-full p-2 hover:scale-105 transition-transform"
               aria-label={isPlaying ? "Pause" : "Play"}
             >
-              {isPlaying ? <Pause size={22} /> : <Play size={22} className="ml-0.5" />}
+              {isPlaying ? (
+                <Pause size={22} />
+              ) : (
+                <Play size={22} className="ml-0.5" />
+              )}
             </button>
             <button
               onClick={next}
@@ -173,27 +140,18 @@ export default function AudioPlayer() {
             </button>
           </div>
 
-          {/* Progress bar */}
+          {/* Waveform progress */}
           <div className="flex items-center gap-3 flex-1 min-w-0">
             <span className="text-xs text-gray-400 w-10 text-right tabular-nums shrink-0">
               {formatTime(currentTime)}
             </span>
-            <div
-              ref={progressBarRef}
-              className="flex-1 h-1.5 bg-gray-700 rounded-full cursor-pointer group relative"
-              onMouseDown={handleProgressMouseDown}
-            >
-              <div
-                className="h-full bg-green-500 rounded-full relative transition-[width] duration-75"
-                style={{ width: `${progress * 100}%` }}
-              >
-                <div
-                  className={`absolute right-0 top-1/2 -translate-y-1/2 w-3 h-3 bg-white rounded-full shadow-md transition-opacity ${
-                    isDragging ? "opacity-100" : "opacity-0 group-hover:opacity-100"
-                  }`}
-                />
-              </div>
-            </div>
+            <WaveformBar
+              postId={currentTrack.id}
+              progress={progress}
+              onSeek={seek}
+              height={24}
+              className="flex-1"
+            />
             <span className="text-xs text-gray-400 w-10 tabular-nums shrink-0">
               {formatTime(duration)}
             </span>

--- a/frontend/src/components/FullScreenPlayer.tsx
+++ b/frontend/src/components/FullScreenPlayer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback, useEffect } from "react";
+import { useRef, useCallback, useEffect } from "react";
 import {
   Play,
   Pause,
@@ -12,6 +12,7 @@ import {
   ListMusic,
 } from "lucide-react";
 import { useAudioPlayer } from "@/hooks/useAudioPlayer";
+import WaveformBar from "./WaveformBar";
 
 const SOURCE_GRADIENTS: Record<string, string> = {
   cloudflare: "from-orange-600 to-amber-800",
@@ -85,8 +86,6 @@ export default function FullScreenPlayer({
     toggleExpanded,
   } = useAudioPlayer();
 
-  const [isDragging, setIsDragging] = useState(false);
-  const progressBarRef = useRef<HTMLDivElement>(null);
   const volumeBarRef = useRef<HTMLDivElement>(null);
   const prevVolumeRef = useRef(volume || 0.75);
 
@@ -101,42 +100,6 @@ export default function FullScreenPlayer({
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isExpanded, toggleExpanded]);
-
-  const handleProgressClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      const bar = progressBarRef.current;
-      if (!bar) return;
-      const rect = bar.getBoundingClientRect();
-      const fraction = (e.clientX - rect.left) / rect.width;
-      seek(fraction);
-    },
-    [seek],
-  );
-
-  const handleProgressMouseDown = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      setIsDragging(true);
-      handleProgressClick(e);
-
-      const handleMouseMove = (ev: MouseEvent) => {
-        const bar = progressBarRef.current;
-        if (!bar) return;
-        const rect = bar.getBoundingClientRect();
-        const fraction = (ev.clientX - rect.left) / rect.width;
-        seek(Math.max(0, Math.min(1, fraction)));
-      };
-
-      const handleMouseUp = () => {
-        setIsDragging(false);
-        document.removeEventListener("mousemove", handleMouseMove);
-        document.removeEventListener("mouseup", handleMouseUp);
-      };
-
-      document.addEventListener("mousemove", handleMouseMove);
-      document.addEventListener("mouseup", handleMouseUp);
-    },
-    [handleProgressClick, seek],
-  );
 
   const handleVolumeClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -252,26 +215,16 @@ export default function FullScreenPlayer({
           </p>
         </div>
 
-        {/* Progress bar */}
+        {/* Waveform progress */}
         <div className="px-8 pb-2">
-          <div
-            ref={progressBarRef}
-            className="w-full h-2 bg-white/20 rounded-full cursor-pointer group relative"
-            onMouseDown={handleProgressMouseDown}
-          >
-            <div
-              className="h-full bg-white rounded-full relative transition-[width] duration-75"
-              style={{ width: `${progress * 100}%` }}
-            >
-              <div
-                className={`absolute right-0 top-1/2 -translate-y-1/2 w-4 h-4 bg-white rounded-full shadow-md transition-opacity ${
-                  isDragging
-                    ? "opacity-100"
-                    : "opacity-0 group-hover:opacity-100"
-                }`}
-              />
-            </div>
-          </div>
+          <WaveformBar
+            postId={currentTrack.id}
+            progress={progress}
+            onSeek={seek}
+            height={32}
+            activeColor="rgba(255, 255, 255, 0.9)"
+            inactiveColor="rgba(255, 255, 255, 0.2)"
+          />
           <div className="flex justify-between mt-1">
             <span className="text-xs text-gray-400 tabular-nums">
               {formatTime(currentTime)}

--- a/frontend/src/components/WaveformBar.tsx
+++ b/frontend/src/components/WaveformBar.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useCallback, useRef, useState, useMemo } from "react";
+
+const BAR_COUNT = 64;
+
+function generateBars(seed: number): number[] {
+  let s = seed | 0;
+  const bars: number[] = [];
+  for (let i = 0; i < BAR_COUNT; i++) {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    const r = ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    bars.push(0.15 + r * 0.85);
+  }
+  return bars;
+}
+
+interface WaveformBarProps {
+  postId: number;
+  progress: number;
+  onSeek: (fraction: number) => void;
+  height?: number;
+  activeColor?: string;
+  inactiveColor?: string;
+  className?: string;
+}
+
+export default function WaveformBar({
+  postId,
+  progress,
+  onSeek,
+  height = 24,
+  activeColor = "rgb(34 197 94)",
+  inactiveColor = "rgb(55 65 81)",
+  className = "",
+}: WaveformBarProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const bars = useMemo(() => generateBars(postId), [postId]);
+
+  const getFraction = useCallback((clientX: number): number => {
+    const el = containerRef.current;
+    if (!el) return 0;
+    const rect = el.getBoundingClientRect();
+    return Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+  }, []);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      setIsDragging(true);
+      onSeek(getFraction(e.clientX));
+
+      const handleMouseMove = (ev: MouseEvent) => {
+        onSeek(getFraction(ev.clientX));
+      };
+      const handleMouseUp = () => {
+        setIsDragging(false);
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+    },
+    [onSeek, getFraction],
+  );
+
+  const gap = 2;
+
+  return (
+    <div
+      ref={containerRef}
+      className={`cursor-pointer select-none ${className}`}
+      style={{ height, position: "relative" }}
+      onMouseDown={handleMouseDown}
+    >
+      <svg
+        width="100%"
+        height="100%"
+        preserveAspectRatio="none"
+        viewBox={`0 0 ${BAR_COUNT * 10} ${height}`}
+        aria-label="Waveform progress"
+        role="progressbar"
+        aria-valuenow={Math.round(progress * 100)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        {bars.map((h, i) => {
+          const barH = h * height;
+          const y = (height - barH) / 2;
+          const x = i * 10;
+          const w = 10 - gap;
+          const fraction = (i + 0.5) / BAR_COUNT;
+          const filled = fraction <= progress;
+
+          return (
+            <rect
+              key={i}
+              x={x}
+              y={y}
+              width={w}
+              height={barH}
+              rx={1.5}
+              fill={filled ? activeColor : inactiveColor}
+              style={{
+                transition: isDragging ? "none" : "fill 0.1s ease",
+              }}
+            />
+          );
+        })}
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `WaveformBar.tsx` component: 64 SVG bars with heights seeded by post ID via mulberry32 PRNG
- Replace flat progress bar in `AudioPlayer.tsx` (mini player, 24px green) and `FullScreenPlayer.tsx` (expanded, 32px white)
- Bars fill with accent color based on playback progress fraction; click/drag seeking supported

Closes #20

## Test plan
- [ ] Play a track and verify waveform renders in the bottom mini player
- [ ] Expand to full-screen player and verify taller white waveform
- [ ] Click/drag on waveform to seek
- [ ] Switch tracks and confirm waveform pattern changes per post