### PR TITLE
feat: add transcript view panel synced to playback

### DIFF
--- a/frontend/src/components/FullScreenPlayer.tsx
+++ b/frontend/src/components/FullScreenPlayer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useCallback, useEffect } from "react";
+import { useRef, useState, useCallback, useEffect } from "react";
 import {
   Play,
   Pause,
@@ -10,9 +10,12 @@ import {
   VolumeX,
   ChevronDown,
   ListMusic,
+  FileText,
 } from "lucide-react";
 import { useAudioPlayer } from "@/hooks/useAudioPlayer";
+import { getPost } from "@/lib/api";
 import WaveformBar from "./WaveformBar";
+import TranscriptPanel from "./TranscriptPanel";
 
 const SOURCE_GRADIENTS: Record<string, string> = {
   cloudflare: "from-orange-600 to-amber-800",
@@ -88,6 +91,50 @@ export default function FullScreenPlayer({
 
   const volumeBarRef = useRef<HTMLDivElement>(null);
   const prevVolumeRef = useRef(volume || 0.75);
+
+  // Transcript state
+  const [transcriptOpen, setTranscriptOpen] = useState(false);
+  const [fullText, setFullText] = useState<string | null>(null);
+  const [transcriptLoading, setTranscriptLoading] = useState(false);
+  const lastFetchedPostIdRef = useRef<number | null>(null);
+
+  // Fetch full text when transcript is toggled on
+  useEffect(() => {
+    if (!transcriptOpen || !currentTrack) return;
+    if (lastFetchedPostIdRef.current === currentTrack.id && fullText !== null) return;
+
+    let cancelled = false;
+    setTranscriptLoading(true);
+    getPost(currentTrack.id)
+      .then((detail) => {
+        if (!cancelled) {
+          setFullText(detail.full_text);
+          lastFetchedPostIdRef.current = detail.id;
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setFullText(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setTranscriptLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [transcriptOpen, currentTrack, fullText]);
+
+  // Reset full text cache when track changes
+  useEffect(() => {
+    if (currentTrack && lastFetchedPostIdRef.current !== currentTrack.id) {
+      setFullText(null);
+      lastFetchedPostIdRef.current = null;
+    }
+  }, [currentTrack]);
 
   // Close on Escape key
   useEffect(() => {
@@ -173,33 +220,75 @@ export default function FullScreenPlayer({
           <span className="text-xs text-gray-400 uppercase tracking-widest font-medium">
             Now Playing
           </span>
-          <button
-            onClick={onQueueToggle}
-            className={`relative p-2 -mr-2 rounded-md transition-colors ${
-              queueOpen
-                ? "text-green-400 bg-white/10"
-                : "text-gray-400 hover:text-white"
-            }`}
-            aria-label="Toggle queue"
-          >
-            <ListMusic size={24} />
-            {queue.length > 0 && (
-              <span className="absolute -top-1 -right-1 bg-green-500 text-black text-[10px] font-bold rounded-full w-4 h-4 flex items-center justify-center">
-                {queue.length > 9 ? "9+" : queue.length}
-              </span>
-            )}
-          </button>
+          <div className="flex items-center gap-2 -mr-2">
+            <button
+              onClick={() => setTranscriptOpen((prev) => !prev)}
+              className={`p-2 rounded-md transition-colors ${
+                transcriptOpen
+                  ? "text-green-400 bg-white/10"
+                  : "text-gray-400 hover:text-white"
+              }`}
+              aria-label="Toggle transcript"
+            >
+              <FileText size={24} />
+            </button>
+            <button
+              onClick={onQueueToggle}
+              className={`relative p-2 rounded-md transition-colors ${
+                queueOpen
+                  ? "text-green-400 bg-white/10"
+                  : "text-gray-400 hover:text-white"
+              }`}
+              aria-label="Toggle queue"
+            >
+              <ListMusic size={24} />
+              {queue.length > 0 && (
+                <span className="absolute -top-1 -right-1 bg-green-500 text-black text-[10px] font-bold rounded-full w-4 h-4 flex items-center justify-center">
+                  {queue.length > 9 ? "9+" : queue.length}
+                </span>
+              )}
+            </button>
+          </div>
         </div>
 
-        {/* Artwork area */}
-        <div className="flex-1 flex items-center justify-center px-8">
-          <div
-            className={`w-64 h-64 sm:w-80 sm:h-80 rounded-2xl bg-gradient-to-br ${gradient} flex items-center justify-center shadow-2xl`}
-          >
-            <span className="text-8xl sm:text-9xl font-bold text-white/80 select-none">
-              {initial}
-            </span>
-          </div>
+        {/* Artwork area / Transcript panel */}
+        <div className="flex-1 flex items-center justify-center px-8 min-h-0">
+          {transcriptOpen ? (
+            <div
+              className="w-full max-w-2xl h-full rounded-2xl overflow-hidden"
+              style={{ backgroundColor: "rgba(255, 255, 255, 0.05)" }}
+            >
+              {transcriptLoading ? (
+                <div className="flex items-center justify-center h-full">
+                  <div
+                    className="w-6 h-6 border-2 border-t-transparent rounded-full animate-spin"
+                    style={{ borderColor: "var(--color-text-muted)", borderTopColor: "transparent" }}
+                  />
+                </div>
+              ) : fullText ? (
+                <TranscriptPanel
+                  fullText={fullText}
+                  currentTime={currentTime}
+                  duration={duration}
+                />
+              ) : (
+                <div
+                  className="flex items-center justify-center h-full"
+                  style={{ color: "var(--color-text-muted)" }}
+                >
+                  <p className="text-sm">No transcript available.</p>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div
+              className={`w-64 h-64 sm:w-80 sm:h-80 rounded-2xl bg-gradient-to-br ${gradient} flex items-center justify-center shadow-2xl`}
+            >
+              <span className="text-8xl sm:text-9xl font-bold text-white/80 select-none">
+                {initial}
+              </span>
+            </div>
+          )}
         </div>
 
         {/* Track info */}

--- a/frontend/src/components/TranscriptPanel.tsx
+++ b/frontend/src/components/TranscriptPanel.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useRef, useState, useEffect, useCallback } from "react";
+
+interface TranscriptPanelProps {
+  fullText: string;
+  currentTime: number;
+  duration: number;
+}
+
+interface Paragraph {
+  text: string;
+  startTime: number;
+  endTime: number;
+}
+
+function splitIntoParagraphs(text: string): string[] {
+  return text
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}
+
+function mapParagraphsToTimeRanges(
+  paragraphs: string[],
+  duration: number,
+): Paragraph[] {
+  if (paragraphs.length === 0 || duration <= 0) return [];
+
+  // Weight each paragraph by character count for proportional time mapping
+  const totalChars = paragraphs.reduce((sum, p) => sum + p.length, 0);
+  if (totalChars === 0) return [];
+
+  let cursor = 0;
+  return paragraphs.map((text) => {
+    const fraction = text.length / totalChars;
+    const startTime = cursor;
+    const endTime = cursor + fraction * duration;
+    cursor = endTime;
+    return { text, startTime, endTime };
+  });
+}
+
+function findActiveParagraphIndex(
+  paragraphs: Paragraph[],
+  currentTime: number,
+): number {
+  for (let i = paragraphs.length - 1; i >= 0; i--) {
+    if (currentTime >= paragraphs[i].startTime) {
+      return i;
+    }
+  }
+  return 0;
+}
+
+export default function TranscriptPanel({
+  fullText,
+  currentTime,
+  duration,
+}: TranscriptPanelProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const paragraphRefs = useRef<(HTMLParagraphElement | null)[]>([]);
+  const [userScrolled, setUserScrolled] = useState(false);
+  const lastActiveIndexRef = useRef(-1);
+  const isAutoScrollingRef = useRef(false);
+
+  const rawParagraphs = splitIntoParagraphs(fullText);
+  const paragraphs = mapParagraphsToTimeRanges(rawParagraphs, duration);
+  const activeIndex = findActiveParagraphIndex(paragraphs, currentTime);
+
+  // Detect manual scroll — pause auto-scroll
+  const handleScroll = useCallback(() => {
+    if (isAutoScrollingRef.current) return;
+    setUserScrolled(true);
+  }, []);
+
+  // Re-enable auto-scroll when active paragraph changes
+  useEffect(() => {
+    if (activeIndex !== lastActiveIndexRef.current) {
+      lastActiveIndexRef.current = activeIndex;
+      setUserScrolled(false);
+    }
+  }, [activeIndex]);
+
+  // Auto-scroll to active paragraph
+  useEffect(() => {
+    if (userScrolled) return;
+    const el = paragraphRefs.current[activeIndex];
+    if (!el) return;
+
+    isAutoScrollingRef.current = true;
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+
+    // Reset the auto-scrolling flag after animation settles
+    const timer = setTimeout(() => {
+      isAutoScrollingRef.current = false;
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [activeIndex, userScrolled]);
+
+  if (paragraphs.length === 0) {
+    return (
+      <div
+        className="flex items-center justify-center h-full"
+        style={{ color: "var(--color-text-muted)" }}
+      >
+        <p className="text-sm">No transcript available for this post.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      onScroll={handleScroll}
+      className="overflow-y-auto h-full px-6 py-4 space-y-4"
+      style={{ scrollbarWidth: "thin" }}
+    >
+      {paragraphs.map((para, i) => {
+        const isActive = i === activeIndex;
+        return (
+          <p
+            key={i}
+            ref={(el) => {
+              paragraphRefs.current[i] = el;
+            }}
+            className="text-sm leading-relaxed transition-all duration-300 ease-in-out rounded-lg px-3 py-2"
+            style={{
+              color: isActive
+                ? "var(--color-text-primary)"
+                : "var(--color-text-muted)",
+              backgroundColor: isActive
+                ? "rgba(255, 255, 255, 0.08)"
+                : "transparent",
+              fontWeight: isActive ? 500 : 400,
+            }}
+          >
+            {para.text}
+          </p>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #21

## Summary
- **New `TranscriptPanel.tsx`**: Splits post `full_text` into paragraphs, maps each to a proportional time range based on character count, highlights the active paragraph, and auto-scrolls smoothly to it. Manual scrolling pauses auto-scroll; it re-syncs when the next paragraph becomes active.
- **Modified `FullScreenPlayer.tsx`**: Added a FileText toggle button in the top bar. When active, fetches the post's full text via `getPost()` and replaces the artwork area with the scrollable transcript panel. Loading spinner shown during fetch; graceful fallback if no text available.

## Test plan
- [ ] Open full-screen player with a podcast that has `full_text`
- [ ] Toggle transcript on — verify paragraphs appear with loading spinner
- [ ] Verify active paragraph highlights and auto-scrolls during playback
- [ ] Manually scroll — confirm auto-scroll pauses
- [ ] Wait for next paragraph change — confirm auto-scroll resumes
- [ ] Toggle transcript off — verify artwork reappears
- [ ] Switch tracks while transcript is open — verify new text loads
- [ ] Test with a post that has no `full_text` — verify "No transcript" message