### PR TITLE
feat: build first-run onboarding flow with source/interest selection

### DIFF
--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import OnboardingFlow from "@/components/onboarding/OnboardingFlow";
+
+const STORAGE_KEY_COMPLETED = "tbc-onboarding-completed";
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const completed = localStorage.getItem(STORAGE_KEY_COMPLETED);
+    if (completed === "true") {
+      router.replace("/");
+    } else {
+      setReady(true);
+    }
+  }, [router]);
+
+  if (!ready) {
+    return null;
+  }
+
+  return <OnboardingFlow />;
+}

--- a/frontend/src/components/onboarding/InterestSelector.tsx
+++ b/frontend/src/components/onboarding/InterestSelector.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Check } from "lucide-react";
+import type { Tag } from "@/lib/types";
+import { getTags } from "@/lib/api";
+
+interface InterestSelectorProps {
+  selected: string[];
+  onChange: (tags: string[]) => void;
+}
+
+export default function InterestSelector({ selected, onChange }: InterestSelectorProps) {
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getTags()
+      .then(setTags)
+      .catch(() => setTags([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  function toggle(slug: string) {
+    if (selected.includes(slug)) {
+      onChange(selected.filter((t) => t !== slug));
+    } else {
+      onChange([...selected, slug]);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div
+          className="w-8 h-8 border-2 border-[var(--color-accent)] border-t-transparent rounded-full animate-spin"
+          aria-label="Loading interests"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      <h2 className="text-xl font-semibold text-[var(--color-text-primary)] mb-2">
+        What interests you?
+      </h2>
+      <p className="text-sm text-[var(--color-text-secondary)] mb-6">
+        Choose topics to personalize your feed. You can update these anytime.
+      </p>
+      <div className="flex flex-wrap gap-3">
+        {tags.map((tag) => {
+          const isSelected = selected.includes(tag.slug);
+          return (
+            <button
+              key={tag.slug}
+              type="button"
+              onClick={() => toggle(tag.slug)}
+              className={`
+                inline-flex items-center gap-2 px-4 py-2.5 rounded-[var(--radius-full)] border-2 text-sm font-medium transition-all cursor-pointer
+                ${
+                  isSelected
+                    ? "border-[var(--color-accent)] bg-[var(--color-accent)] text-[var(--color-accent-text)]"
+                    : "border-[var(--color-border)] bg-[var(--color-bg-secondary)] text-[var(--color-text-primary)] hover:border-[var(--color-border-hover)]"
+                }
+              `}
+            >
+              {isSelected && <Check className="w-3.5 h-3.5" />}
+              {tag.name}
+              <span
+                className={`text-xs ${
+                  isSelected ? "text-[var(--color-accent-text)]/70" : "text-[var(--color-text-muted)]"
+                }`}
+              >
+                ({tag.post_count})
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/onboarding/OnboardingFlow.tsx
+++ b/frontend/src/components/onboarding/OnboardingFlow.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowRight, SkipForward } from "lucide-react";
+import Logo from "@/components/Logo";
+import SourceSelector from "./SourceSelector";
+import InterestSelector from "./InterestSelector";
+
+const TOTAL_STEPS = 3;
+
+const STORAGE_KEY_COMPLETED = "tbc-onboarding-completed";
+const STORAGE_KEY_PREFERENCES = "tbc-user-preferences";
+
+export default function OnboardingFlow() {
+  const router = useRouter();
+  const [step, setStep] = useState(0);
+  const [selectedSources, setSelectedSources] = useState<string[]>([]);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+
+  const finish = useCallback(() => {
+    localStorage.setItem(STORAGE_KEY_COMPLETED, "true");
+    localStorage.setItem(
+      STORAGE_KEY_PREFERENCES,
+      JSON.stringify({ sources: selectedSources, tags: selectedTags })
+    );
+    router.push("/");
+  }, [selectedSources, selectedTags, router]);
+
+  const skip = useCallback(() => {
+    localStorage.setItem(STORAGE_KEY_COMPLETED, "true");
+    localStorage.setItem(
+      STORAGE_KEY_PREFERENCES,
+      JSON.stringify({ sources: [], tags: [] })
+    );
+    router.push("/");
+  }, [router]);
+
+  const next = useCallback(() => {
+    if (step < TOTAL_STEPS - 1) {
+      setStep((s) => s + 1);
+    } else {
+      finish();
+    }
+  }, [step, finish]);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center px-4 py-12 bg-[var(--color-bg-primary)]">
+      <div className="w-full max-w-lg flex flex-col items-center">
+        {/* Progress dots */}
+        <div className="flex items-center gap-2 mb-10">
+          {Array.from({ length: TOTAL_STEPS }).map((_, i) => (
+            <span
+              key={i}
+              className={`w-2.5 h-2.5 rounded-full transition-colors ${
+                i === step
+                  ? "bg-[var(--color-accent)]"
+                  : i < step
+                    ? "bg-[var(--color-accent)]/40"
+                    : "bg-[var(--color-bg-tertiary)]"
+              }`}
+            />
+          ))}
+        </div>
+
+        {/* Step content */}
+        <div className="w-full min-h-[340px] flex flex-col items-center">
+          {step === 0 && (
+            <div className="flex flex-col items-center text-center gap-6">
+              <Logo variant="icon" className="w-16 h-16 text-[var(--color-accent)]" />
+              <div>
+                <h1 className="text-2xl font-bold text-[var(--color-text-primary)] mb-3">
+                  Welcome to Tech Blog Catchup
+                </h1>
+                <p className="text-[var(--color-text-secondary)] leading-relaxed max-w-md">
+                  Stay on top of engineering blogs from the world&apos;s best tech companies.
+                  We turn long-form articles into bite-sized conversational podcasts so you
+                  can listen on the go.
+                </p>
+              </div>
+              <button
+                onClick={next}
+                className="inline-flex items-center gap-2 px-6 py-3 bg-[var(--color-accent)] hover:bg-[var(--color-accent-hover)] text-[var(--color-accent-text)] font-semibold rounded-[var(--radius-lg)] transition-colors cursor-pointer"
+              >
+                Get Started
+                <ArrowRight className="w-4 h-4" />
+              </button>
+            </div>
+          )}
+
+          {step === 1 && (
+            <SourceSelector selected={selectedSources} onChange={setSelectedSources} />
+          )}
+
+          {step === 2 && (
+            <InterestSelector selected={selectedTags} onChange={setSelectedTags} />
+          )}
+        </div>
+
+        {/* Bottom navigation (steps 1 and 2 only) */}
+        {step > 0 && (
+          <div className="w-full flex items-center justify-between mt-8 pt-6 border-t border-[var(--color-border)]">
+            <button
+              onClick={skip}
+              className="inline-flex items-center gap-1.5 px-4 py-2 text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors cursor-pointer"
+            >
+              <SkipForward className="w-4 h-4" />
+              Skip
+            </button>
+            <button
+              onClick={next}
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-[var(--color-accent)] hover:bg-[var(--color-accent-hover)] text-[var(--color-accent-text)] font-medium rounded-[var(--radius-lg)] transition-colors cursor-pointer"
+            >
+              {step === TOTAL_STEPS - 1 ? "Finish" : "Continue"}
+              <ArrowRight className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+
+        {/* Skip on welcome screen */}
+        {step === 0 && (
+          <button
+            onClick={skip}
+            className="mt-6 inline-flex items-center gap-1.5 text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors cursor-pointer"
+          >
+            <SkipForward className="w-4 h-4" />
+            Skip setup
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/onboarding/SourceSelector.tsx
+++ b/frontend/src/components/onboarding/SourceSelector.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Check } from "lucide-react";
+import type { Source } from "@/lib/types";
+import { getSources } from "@/lib/api";
+
+interface SourceSelectorProps {
+  selected: string[];
+  onChange: (sources: string[]) => void;
+}
+
+export default function SourceSelector({ selected, onChange }: SourceSelectorProps) {
+  const [sources, setSources] = useState<Source[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getSources()
+      .then(setSources)
+      .catch(() => setSources([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  function toggle(key: string) {
+    if (selected.includes(key)) {
+      onChange(selected.filter((s) => s !== key));
+    } else {
+      onChange([...selected, key]);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div
+          className="w-8 h-8 border-2 border-[var(--color-accent)] border-t-transparent rounded-full animate-spin"
+          aria-label="Loading sources"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      <h2 className="text-xl font-semibold text-[var(--color-text-primary)] mb-2">
+        Pick your favorite sources
+      </h2>
+      <p className="text-sm text-[var(--color-text-secondary)] mb-6">
+        Select the engineering blogs you want to follow. You can change these later.
+      </p>
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        {sources.map((source) => {
+          const isSelected = selected.includes(source.key);
+          return (
+            <button
+              key={source.key}
+              type="button"
+              onClick={() => toggle(source.key)}
+              className={`
+                relative flex flex-col items-start gap-1 p-4 rounded-[var(--radius-lg)] border-2 transition-all cursor-pointer text-left
+                ${
+                  isSelected
+                    ? "border-[var(--color-accent)] bg-[var(--color-accent)]/10"
+                    : "border-[var(--color-border)] bg-[var(--color-bg-secondary)] hover:border-[var(--color-border-hover)]"
+                }
+              `}
+            >
+              {isSelected && (
+                <span className="absolute top-2 right-2 w-5 h-5 rounded-full bg-[var(--color-accent)] flex items-center justify-center">
+                  <Check className="w-3 h-3 text-[var(--color-accent-text)]" />
+                </span>
+              )}
+              <span className="text-sm font-medium text-[var(--color-text-primary)] leading-tight">
+                {source.name}
+              </span>
+              <span className="text-xs text-[var(--color-text-muted)]">
+                {source.post_count} {source.post_count === 1 ? "post" : "posts"}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 3-step onboarding wizard: Welcome screen with logo/description, source picker (checkbox grid from `/api/sources`), interest/tag picker (chip grid from `/api/tags`)
- Progress dots, Skip button on every step, Continue/Finish navigation
- Saves `tbc-onboarding-completed` and `tbc-user-preferences` to localStorage, redirects to `/`
- `/onboarding` page redirects to `/` if already completed

## Test plan
- [ ] Visit `/onboarding` as new user (clear localStorage) -- should show welcome screen
- [ ] Click Get Started, select sources, Continue, select tags, Finish -- verify localStorage keys set and redirect to `/`
- [ ] Revisit `/onboarding` -- should redirect to `/` immediately
- [ ] Test Skip on each step -- should save empty prefs and redirect
- [ ] Verify `npm run build` passes cleanly

Closes #37