### PR TITLE
feat: improve accessibility with ARIA labels, focus management, and skip links

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -45,6 +45,12 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] min-h-screen`}>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-[var(--color-accent)] focus:text-[var(--color-accent-text)] focus:rounded-[var(--radius-md)]"
+        >
+          Skip to content
+        </a>
         <ThemeProvider>
           <SessionProvider>
             <AudioPlayerProvider>
@@ -54,7 +60,7 @@ export default function RootLayout({
                 <div className="fixed top-4 right-4 z-50">
                   <ThemeToggle />
                 </div>
-                <main className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8 pb-24">
+                <main id="main-content" className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8 pb-24">
                   {children}
                 </main>
                 <Footer />

--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -96,7 +96,7 @@ export default function AudioPlayer() {
       <div className="fixed bottom-0 left-0 right-0 z-50 bg-gray-900 border-t border-gray-800 h-20 select-none">
         <div className="h-full max-w-full mx-auto px-4 flex items-center gap-4">
           {/* Track info */}
-          <div className="flex flex-col min-w-0 w-56 shrink-0">
+          <div className="flex flex-col min-w-0 w-56 shrink-0" aria-live="polite">
             <span className="text-xs text-gray-400 truncate">
               {currentTrack.source_name}
             </span>
@@ -141,7 +141,11 @@ export default function AudioPlayer() {
           </div>
 
           {/* Waveform progress */}
-          <div className="flex items-center gap-3 flex-1 min-w-0">
+          <div
+            className="flex items-center gap-3 flex-1 min-w-0"
+            role="group"
+            aria-label="Playback progress"
+          >
             <span className="text-xs text-gray-400 w-10 text-right tabular-nums shrink-0">
               {formatTime(currentTime)}
             </span>
@@ -168,6 +172,12 @@ export default function AudioPlayer() {
             </button>
             <div
               ref={volumeBarRef}
+              role="slider"
+              aria-label="Volume"
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={Math.round(volume * 100)}
+              tabIndex={0}
               className="w-24 h-1.5 bg-gray-700 rounded-full cursor-pointer group relative"
               onMouseDown={handleVolumeMouseDown}
             >

--- a/frontend/src/components/SearchDialog.tsx
+++ b/frontend/src/components/SearchDialog.tsx
@@ -74,6 +74,8 @@ interface SearchDialogProps {
 export default function SearchDialog({ open, onClose }: SearchDialogProps) {
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<Post[]>([]);
   const [loading, setLoading] = useState(false);
@@ -83,13 +85,51 @@ export default function SearchDialog({ open, onClose }: SearchDialogProps) {
 
   useEffect(() => {
     if (open) {
+      triggerRef.current = document.activeElement as HTMLElement;
       setQuery("");
       setResults([]);
       setSelectedIndex(0);
       setHasSearched(false);
       setRecentSearches(getRecentSearches());
       requestAnimationFrame(() => inputRef.current?.focus());
+    } else if (triggerRef.current) {
+      triggerRef.current.focus();
+      triggerRef.current = null;
     }
+  }, [open]);
+
+  // Focus trap: cycle Tab through dialog elements only
+  useEffect(() => {
+    if (!open) return;
+
+    const handleFocusTrap = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+
+      const focusable = dialog.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleFocusTrap);
+    return () => document.removeEventListener("keydown", handleFocusTrap);
   }, [open]);
 
   useEffect(() => {
@@ -176,9 +216,13 @@ export default function SearchDialog({ open, onClose }: SearchDialogProps) {
     <div
       className="fixed inset-0 z-[100] flex items-start justify-center pt-[15vh]"
       onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Search"
     >
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
       <div
+        ref={dialogRef}
         className="relative w-full max-w-lg mx-4 bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-[var(--radius-lg)] shadow-2xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
@@ -198,6 +242,7 @@ export default function SearchDialog({ open, onClose }: SearchDialogProps) {
           )}
           <button
             onClick={onClose}
+            aria-label="Close search"
             className="shrink-0 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
           >
             <X size={16} />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -65,6 +65,8 @@ export default function Sidebar() {
 
   return (
     <aside
+      role="navigation"
+      aria-label="Main navigation"
       className="hidden md:flex flex-col fixed top-0 left-0 h-screen border-r border-[var(--color-border)] bg-[var(--color-bg-secondary)] transition-[width] duration-300 ease-in-out"
       style={{
         width: mounted ? (collapsed ? 72 : 240) : 240,
@@ -86,6 +88,7 @@ export default function Sidebar() {
         <button
           onClick={() => setSearchOpen(true)}
           title={collapsed ? "Search (Cmd+K)" : undefined}
+          aria-label="Search posts"
           className="flex items-center gap-3 w-full rounded-[var(--radius-md)] px-3 py-2.5 text-sm font-medium text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-text-primary)] transition-colors"
         >
           <Search size={20} className="shrink-0" />
@@ -104,7 +107,7 @@ export default function Sidebar() {
       </div>
 
       {/* Nav items */}
-      <nav className="flex-1 py-4 flex flex-col gap-1 px-3 overflow-y-auto">
+      <nav role="list" className="flex-1 py-4 flex flex-col gap-1 px-3 overflow-y-auto">
         {navItems.map(({ href, label, icon: Icon }) => {
           const active = href === "/" ? pathname === "/" : pathname.startsWith(href);
           return (


### PR DESCRIPTION
Closes #36

## Summary
- **layout.tsx**: Skip-to-content link (sr-only, visible on focus) + `id="main-content"` landmark on `<main>`
- **Sidebar.tsx**: `role="navigation"` + `aria-label="Main navigation"` on aside, `role="list"` on nav, `aria-label` on search button
- **AudioPlayer.tsx**: `aria-live="polite"` on track info, `role="slider"` with `aria-valuemin/max/now` on volume, `role="group"` on progress area
- **SearchDialog.tsx**: `role="dialog"` + `aria-modal="true"` + `aria-label="Search"`, focus trap (Tab cycles within dialog), focus returns to trigger on close, close button labeled

## Test plan
- [ ] Tab through page — skip link appears first, jumps to main content
- [ ] Open search dialog — focus trapped inside, Escape closes and returns focus to search button
- [ ] Screen reader announces track changes in audio player
- [ ] Volume slider is keyboard-accessible and announced with current value
- [ ] Sidebar nav items are properly announced as navigation