### PR TITLE
fix: read AUDIO_DIR env var and log CORS origins

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,10 @@
+# Required for podcast generation (OpenAI TTS)
 OPENAI_API_KEY=your-key-here
+
+# CORS origins — comma-separated list of allowed frontend URLs
+# Add your production frontend URL here (e.g., https://techblog.up.railway.app)
 CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
+# Audio directory — override to use a persistent volume in production
+# Defaults to backend/audio/ relative to source tree
+# AUDIO_DIR=/app/audio

--- a/backend/src/api/app.py
+++ b/backend/src/api/app.py
@@ -1,5 +1,6 @@
 """FastAPI application setup."""
 
+import logging
 import os
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -12,6 +13,8 @@ from slowapi import _rate_limit_exceeded_handler
 from src.api.rate_limit import limiter
 from src.api.routes import router
 from src.database import init_db
+
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -51,17 +54,24 @@ def create_app() -> FastAPI:
         "CORS_ORIGINS",
         "http://localhost:3000,http://127.0.0.1:3000",
     ).split(",")
+    allowed_origins = [o.strip() for o in origins if o.strip()]
+    logger.info("CORS allowed origins: %s", allowed_origins)
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=[o.strip() for o in origins],
+        allow_origins=allowed_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
     )
 
     # Mount audio directory for serving MP3 files
-    audio_dir = Path(__file__).parent.parent.parent / "audio"
-    audio_dir.mkdir(exist_ok=True)
+    env_audio_dir = os.getenv("AUDIO_DIR")
+    if env_audio_dir:
+        audio_dir = Path(env_audio_dir)
+    else:
+        audio_dir = Path(__file__).parent.parent.parent / "audio"
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    logger.info("Serving audio from: %s", audio_dir.resolve())
     app.mount("/audio", StaticFiles(directory=str(audio_dir)), name="audio")
 
     # Include API routes

--- a/backend/src/podcast/generator.py
+++ b/backend/src/podcast/generator.py
@@ -45,7 +45,11 @@ def generate_podcast_for_post(post: Post, config: Config) -> tuple[str, int] | N
         logger.error("OPENAI_API_KEY not set, cannot generate TTS audio")
         return None
 
-    audio_dir = Path(__file__).parent.parent.parent / config.app.get("audio_dir", "audio")
+    env_audio_dir = os.environ.get("AUDIO_DIR")
+    if env_audio_dir:
+        audio_dir = Path(env_audio_dir)
+    else:
+        audio_dir = Path(__file__).parent.parent.parent / config.app.get("audio_dir", "audio")
     audio_dir.mkdir(parents=True, exist_ok=True)
 
     filename = f"{post.source_key}_{post.id}.mp3"


### PR DESCRIPTION
Closes #105, Closes #106

## Changes
- `generator.py` and `app.py` now read `AUDIO_DIR` env var with fallback to config/relative path
- CORS origins logged on startup for easier debugging
- Audio directory path logged on startup
- `.env.example` updated with `AUDIO_DIR` and better CORS docs

## Test plan
- [ ] Set `AUDIO_DIR=/tmp/test-audio`, verify both generator and app use it
- [ ] Unset `AUDIO_DIR`, verify existing behavior unchanged (175 tests pass)
- [ ] Check startup logs show CORS origins and audio directory