### PR TITLE
feat: make OAuth optional for anonymous browsing

### DIFF
--- a/frontend/src/components/AuthGuard.tsx
+++ b/frontend/src/components/AuthGuard.tsx
@@ -3,7 +3,12 @@
 import { useRequireAuth } from "@/hooks/useRequireAuth";
 
 export default function AuthGuard({ children }: { children: React.ReactNode }) {
-  const { loading } = useRequireAuth();
+  const { loading, authEnabled } = useRequireAuth();
+
+  // When no OAuth providers are configured, allow anonymous access
+  if (!authEnabled) {
+    return <>{children}</>;
+  }
 
   if (loading) {
     return (

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
 import Logo from "./Logo";
 import UserMenu from "./UserMenu";
 import SearchDialog from "./SearchDialog";
+import { useAuthEnabled } from "@/hooks/useRequireAuth";
 
 const STORAGE_KEY = "sidebar-collapsed";
 
@@ -36,6 +37,7 @@ export default function Sidebar() {
     return localStorage.getItem(STORAGE_KEY) === "true";
   });
   const [searchOpen, setSearchOpen] = useState(false);
+  const authEnabled = useAuthEnabled();
 
   const handleGlobalKeyDown = useCallback((e: KeyboardEvent) => {
     if ((e.metaKey || e.ctrlKey) && e.key === "k") {
@@ -124,10 +126,12 @@ export default function Sidebar() {
         })}
       </nav>
 
-      {/* User menu */}
-      <div className="px-3 py-2 border-t border-[var(--color-border)]">
-        <UserMenu collapsed={collapsed} />
-      </div>
+      {/* User menu — hidden when no OAuth providers configured */}
+      {authEnabled !== false && (
+        <div className="px-3 py-2 border-t border-[var(--color-border)]">
+          <UserMenu collapsed={collapsed} />
+        </div>
+      )}
 
       {/* Collapse toggle */}
       <button

--- a/frontend/src/hooks/useRequireAuth.ts
+++ b/frontend/src/hooks/useRequireAuth.ts
@@ -1,26 +1,73 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
+
+/** Cache the auth-enabled check across hook instances */
+let _authEnabledCache: boolean | null = null;
+
+async function checkAuthEnabled(): Promise<boolean> {
+  if (_authEnabledCache !== null) return _authEnabledCache;
+  try {
+    const res = await fetch("/api/auth/providers");
+    if (!res.ok) {
+      _authEnabledCache = false;
+      return false;
+    }
+    const providers = await res.json();
+    _authEnabledCache = Object.keys(providers).length > 0;
+    return _authEnabledCache;
+  } catch {
+    _authEnabledCache = false;
+    return false;
+  }
+}
+
+/** Lightweight hook that only checks if auth is enabled (no redirect) */
+export function useAuthEnabled() {
+  const [enabled, setEnabled] = useState<boolean | null>(_authEnabledCache);
+
+  useEffect(() => {
+    checkAuthEnabled().then(setEnabled);
+  }, []);
+
+  return enabled;
+}
 
 export function useRequireAuth() {
   const { data: session, status } = useSession();
   const router = useRouter();
+  const [authEnabled, setAuthEnabled] = useState<boolean | null>(_authEnabledCache);
 
   useEffect(() => {
-    if (status === "unauthenticated") {
+    checkAuthEnabled().then(setAuthEnabled);
+  }, []);
+
+  useEffect(() => {
+    // Only redirect to login if auth is actually configured
+    if (authEnabled && status === "unauthenticated") {
       router.replace("/login");
     }
-  }, [status, router]);
+  }, [authEnabled, status, router]);
+
+  // Still checking if auth is enabled
+  if (authEnabled === null) {
+    return { loading: true, session: null, authEnabled: null } as const;
+  }
+
+  // Auth not configured — allow anonymous access
+  if (!authEnabled) {
+    return { loading: false, session: null, authEnabled: false } as const;
+  }
 
   if (status === "loading") {
-    return { loading: true, session: null } as const;
+    return { loading: true, session: null, authEnabled: true } as const;
   }
 
   if (status === "authenticated") {
-    return { loading: false, session } as const;
+    return { loading: false, session, authEnabled: true } as const;
   }
 
-  return { loading: true, session: null } as const;
+  return { loading: true, session: null, authEnabled: true } as const;
 }

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,18 +1,32 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 import GitHub from "next-auth/providers/github";
+import type { Provider } from "next-auth/providers";
+
+const providers: Provider[] = [];
+
+if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+  providers.push(
+    Google({
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    })
+  );
+}
+
+if (process.env.GITHUB_ID && process.env.GITHUB_SECRET) {
+  providers.push(
+    GitHub({
+      clientId: process.env.GITHUB_ID,
+      clientSecret: process.env.GITHUB_SECRET,
+    })
+  );
+}
+
+export const authEnabled = providers.length > 0;
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
-  providers: [
-    Google({
-      clientId: process.env.GOOGLE_CLIENT_ID!,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-    }),
-    GitHub({
-      clientId: process.env.GITHUB_ID!,
-      clientSecret: process.env.GITHUB_SECRET!,
-    }),
-  ],
+  providers,
   session: { strategy: "jwt" },
   pages: { signIn: "/login" },
 });


### PR DESCRIPTION
Closes #109

## Changes
- OAuth providers are now conditional in `auth.ts` — only registered when env vars are present
- Removed `!` non-null assertions; empty providers array when no OAuth configured
- `AuthGuard` renders children directly when auth is not configured
- `useRequireAuth` checks `/api/auth/providers` to detect if auth is enabled (cached)
- `Sidebar` hides UserMenu when no OAuth providers configured
- Status page was already public (no AuthGuard to remove)

## Test plan
- [ ] App builds and runs without ANY OAuth env vars
- [ ] Browse, explore, listen all work anonymously
- [ ] Status page accessible without login
- [ ] When OAuth IS configured, login works as before
- [ ] Profile/settings pages still require auth when OAuth is configured