### PR TITLE
docs: document all env vars in .env.example files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,9 @@ config.yaml ──> Crawler (Crawl4AI + atoma RSS) ──> SQLite (SQLAlchemy OR
 
 - **All CLI commands** run from `backend/` via `python run.py <command>`.
 - **Config is centralized** in `backend/config.yaml` — sources, tags, podcast settings, crawl rate limits, app paths.
-- **Environment variables**: `OPENAI_API_KEY` (for podcast generation), `CORS_ORIGINS` (comma-separated), `NEXT_PUBLIC_API_URL` (frontend's backend URL).
+- **Environment variables**: See `.env.example` files in `backend/` and `frontend/` for the full list. Quick reference:
+  - **Backend**: `OPENAI_API_KEY` (required), `CORS_ORIGINS`, `AUDIO_DIR`, `AUDIO_BASE_URL`, `DATABASE_URL`, `NEXTAUTH_SECRET` (if OAuth), `FIRECRAWL_API_KEY` (optional).
+  - **Frontend**: `NEXT_PUBLIC_API_URL` (required, baked at build time), `AUTH_SECRET` (if OAuth), `GOOGLE_CLIENT_ID/SECRET`, `GITHUB_ID/SECRET`.
 - **Database** is SQLite, auto-created at `backend/data/techblog.db`. Both `data/` and `audio/` directories are gitignored.
 - **Post.audio_status** lifecycle: `pending` -> `processing` -> `ready` | `failed`.
 - **Crawl mode**: Unified "smart" crawl discovers via all methods (sitemap, Medium archive, blog page, RSS), deduplicates, filters junk URLs, extracts. Use `--max-posts N` to cap per source.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,10 +1,40 @@
-# Required for podcast generation (OpenAI TTS)
+# ============================================================
+# Backend Environment Variables
+# Copy to .env and fill in required values
+# ============================================================
+
+# --- Required ---
+
+# OpenAI API key for podcast generation (LLM script + TTS audio)
 OPENAI_API_KEY=your-key-here
 
+# --- Optional ---
+
 # CORS origins — comma-separated list of allowed frontend URLs
-# Add your production frontend URL here (e.g., https://techblog.up.railway.app)
+# Default: http://localhost:3000,http://127.0.0.1:3000
 CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 
-# Audio directory — override to use a persistent volume in production
-# Defaults to backend/audio/ relative to source tree
+# Audio file storage directory
+# Default: backend/audio/ (relative to source tree)
+# Set to a persistent volume path in production (e.g., /app/audio)
 # AUDIO_DIR=/app/audio
+
+# Public URL prefix for serving audio files
+# Default: /audio
+# AUDIO_BASE_URL=/audio
+
+# Database connection string
+# Default: sqlite:///data/techblog.db (relative to backend/)
+# DATABASE_URL=sqlite:///data/techblog.db
+
+# --- Conditional (required only if OAuth is configured on frontend) ---
+
+# JWT secret for validating NextAuth tokens in backend auth middleware
+# Must match AUTH_SECRET in frontend/.env
+# NEXTAUTH_SECRET=your-secret-here
+
+# --- Optional integrations ---
+
+# Firecrawl API key — enables Firecrawl as a Tier 3 extraction strategy
+# App works without it; falls back to Trafilatura + BS4
+# FIRECRAWL_API_KEY=your-firecrawl-key-here

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,27 @@
-NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET=your-secret-here
-GOOGLE_CLIENT_ID=your-google-client-id
-GOOGLE_CLIENT_SECRET=your-google-client-secret
-GITHUB_ID=your-github-id
-GITHUB_SECRET=your-github-secret
+# ============================================================
+# Frontend Environment Variables
+# Copy to .env.local and fill in required values
+# ============================================================
+
+# --- Required ---
+
+# Backend API URL
+# IMPORTANT: This is baked at build time in Docker (NEXT_PUBLIC_ prefix)
+# Default: http://localhost:8000
+NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# --- Conditional (required only if OAuth is configured) ---
+
+# NextAuth v5 JWT signing secret (generate with: openssl rand -base64 32)
+# Must match NEXTAUTH_SECRET in backend/.env
+# AUTH_SECRET=your-secret-here
+
+# --- Optional OAuth providers (app works without these) ---
+
+# Google OAuth
+# GOOGLE_CLIENT_ID=your-google-client-id
+# GOOGLE_CLIENT_SECRET=your-google-client-secret
+
+# GitHub OAuth
+# GITHUB_ID=your-github-id
+# GITHUB_SECRET=your-github-secret


### PR DESCRIPTION
Closes #108

## Changes
- Updated `backend/.env.example` with all 7 env vars (grouped by required/optional/conditional)
- Updated `frontend/.env.example` with all 6 env vars (was missing `NEXT_PUBLIC_API_URL`, had uncommented optional vars)
- Added env var quick reference to `CLAUDE.md` Key Conventions section

## Test plan
- [ ] New dev can copy `.env.example` files and fill in values
- [ ] Comments explain build-time vs runtime for `NEXT_PUBLIC_API_URL`
- [ ] `AUTH_SECRET` / `NEXTAUTH_SECRET` cross-reference is documented