### PR TITLE
feat: add /submit page for user content podcastification

### DIFF
--- a/frontend/src/app/submit/page.tsx
+++ b/frontend/src/app/submit/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { FileSearch, Scroll, AudioLines } from "lucide-react";
+import SubmitForm from "@/components/SubmitForm";
+
+const steps = [
+  {
+    icon: FileSearch,
+    title: "Extract",
+    description: "We fetch and parse the article content from the URL or your pasted text.",
+  },
+  {
+    icon: Scroll,
+    title: "Script",
+    description: "An AI generates a conversational podcast script with two hosts.",
+  },
+  {
+    icon: AudioLines,
+    title: "Audio",
+    description: "Text-to-speech creates a natural-sounding podcast episode for you.",
+  },
+];
+
+export default function SubmitPage() {
+  return (
+    <div className="max-w-2xl mx-auto py-8 px-4">
+      {/* Header */}
+      <div className="text-center mb-8">
+        <h1 className="text-4xl font-extrabold text-[var(--text-1)] mb-2">
+          Podcastify
+        </h1>
+        <p className="text-[var(--text-2)] text-base">
+          Turn any article into a podcast
+        </p>
+      </div>
+
+      {/* Submit form */}
+      <SubmitForm />
+
+      {/* How it works */}
+      <div className="mt-12">
+        <h2 className="text-lg font-bold text-[var(--text-1)] text-center mb-6">
+          How it works
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          {steps.map(({ icon: Icon, title, description }, i) => (
+            <div
+              key={title}
+              className="bg-[var(--bg-elevated)] border-[var(--border-w)] border-[var(--border-color)] rounded-[var(--radius-xl)] shadow-[var(--shadow-sm)] p-5 text-center"
+            >
+              <div className="flex items-center justify-center w-10 h-10 mx-auto mb-3 rounded-[var(--radius)] bg-[var(--primary)]/10 text-[var(--primary)]">
+                <Icon size={22} />
+              </div>
+              <p className="text-xs text-[var(--text-3)] font-semibold uppercase tracking-wide mb-1">
+                Step {i + 1}
+              </p>
+              <p className="text-sm font-bold text-[var(--text-1)] mb-1">
+                {title}
+              </p>
+              <p className="text-xs text-[var(--text-2)] leading-relaxed">
+                {description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/BottomTabs.tsx
+++ b/frontend/src/components/BottomTabs.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Home, Compass, LayoutGrid, Library, ListMusic } from "lucide-react";
+import { Home, Compass, LayoutGrid, Library, ListMusic, PlusCircle } from "lucide-react";
 
 const tabs = [
   { href: "/", label: "Home", icon: Home },
@@ -10,6 +10,7 @@ const tabs = [
   { href: "/browse", label: "Browse", icon: LayoutGrid },
   { href: "/library", label: "Library", icon: Library },
   { href: "/playlist", label: "Playlist", icon: ListMusic },
+  { href: "/submit", label: "Submit", icon: PlusCircle },
 ];
 
 export default function BottomTabs() {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   Library,
   ListMusic,
   BarChart3,
+  PlusCircle,
   ChevronLeft,
   ChevronRight,
   Search,
@@ -28,6 +29,7 @@ const navItems = [
   { href: "/library", label: "Library", icon: Library },
   { href: "/playlist", label: "Playlist", icon: ListMusic },
   { href: "/status", label: "Status", icon: BarChart3 },
+  { href: "/submit", label: "Submit", icon: PlusCircle },
 ];
 
 export default function Sidebar() {

--- a/frontend/src/components/SubmitForm.tsx
+++ b/frontend/src/components/SubmitForm.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  Link2,
+  FileText,
+  Headphones,
+  Loader2,
+  CheckCircle2,
+  AlertTriangle,
+} from "lucide-react";
+import { submitPost } from "@/lib/api";
+import { ApiError } from "@/lib/api";
+
+type TabMode = "url" | "text";
+
+interface SuccessResult {
+  post_id: number;
+  job_id: number;
+}
+
+function isValidUrl(str: string): boolean {
+  try {
+    const url = new URL(str);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export default function SubmitForm() {
+  const [tab, setTab] = useState<TabMode>("url");
+  const [url, setUrl] = useState("");
+  const [title, setTitle] = useState("");
+  const [text, setText] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<SuccessResult | null>(null);
+
+  function resetForm() {
+    setUrl("");
+    setTitle("");
+    setText("");
+    setError(null);
+    setSuccess(null);
+  }
+
+  function switchTab(next: TabMode) {
+    if (next !== tab) {
+      resetForm();
+      setTab(next);
+    }
+  }
+
+  function validate(): string | null {
+    if (tab === "url") {
+      if (!url.trim()) return "URL is required";
+      if (!isValidUrl(url.trim())) return "Please enter a valid URL (https://...)";
+    } else {
+      if (!title.trim()) return "Title is required for text submissions";
+      if (!text.trim()) return "Text content is required";
+      if (text.trim().length < 100) return "Text must be at least 100 characters";
+    }
+    return null;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const payload =
+        tab === "url"
+          ? { url: url.trim() }
+          : { text: text.trim(), title: title.trim() };
+      const result = await submitPost(payload);
+      setSuccess({ post_id: result.post_id, job_id: result.job_id });
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.details || err.message);
+      } else {
+        setError("Something went wrong. Please try again.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const tabs: { mode: TabMode; label: string; icon: typeof Link2 }[] = [
+    { mode: "url", label: "Paste URL", icon: Link2 },
+    { mode: "text", label: "Paste Text", icon: FileText },
+  ];
+
+  return (
+    <div className="bg-[var(--bg-elevated)] border-[var(--border-w)] border-[var(--border-color)] rounded-[var(--radius-xl)] shadow-[var(--shadow-lg)] overflow-hidden">
+      {/* Tab switcher */}
+      <div className="flex border-b-[var(--border-w)] border-[var(--border-color)]">
+        {tabs.map(({ mode, label, icon: Icon }) => (
+          <button
+            key={mode}
+            onClick={() => switchTab(mode)}
+            className={`flex-1 flex items-center justify-center gap-2 px-4 py-3 text-sm font-semibold transition-colors ${
+              tab === mode
+                ? "bg-[var(--primary)] text-[var(--primary-text)]"
+                : "text-[var(--text-2)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-1)]"
+            }`}
+          >
+            <Icon size={18} />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Form body */}
+      <form onSubmit={handleSubmit} className="p-6 space-y-5">
+        {/* Error banner */}
+        {error && (
+          <div className="flex items-start gap-2 bg-[var(--error)]/10 border-[var(--border-w)] border-[var(--error)]/50 text-[var(--error)] rounded-[var(--radius)] p-3 text-sm">
+            <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {/* Success banner */}
+        {success && (
+          <div className="flex items-start gap-2 bg-[var(--primary)]/10 border-[var(--border-w)] border-[var(--primary)]/50 text-[var(--primary)] rounded-[var(--radius)] p-3 text-sm">
+            <CheckCircle2 size={16} className="mt-0.5 shrink-0" />
+            <span>
+              Podcast queued!{" "}
+              <Link
+                href={`/post/${success.post_id}`}
+                className="underline font-semibold hover:opacity-80"
+              >
+                View post &rarr;
+              </Link>
+            </span>
+          </div>
+        )}
+
+        {/* URL input */}
+        {tab === "url" && (
+          <div>
+            <label
+              htmlFor="submit-url"
+              className="block text-sm font-semibold text-[var(--text-1)] mb-2"
+            >
+              Article URL
+            </label>
+            <input
+              id="submit-url"
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://engineering.example.com/article..."
+              disabled={loading}
+              className="w-full px-4 py-3 bg-[var(--bg-main)] text-[var(--text-1)] placeholder:text-[var(--text-3)] border-[var(--border-w)] border-[var(--border-color)] rounded-[var(--radius)] shadow-[var(--shadow-sm)] text-sm focus:outline-none focus:border-[var(--primary)] transition-colors disabled:opacity-50"
+            />
+          </div>
+        )}
+
+        {/* Text inputs */}
+        {tab === "text" && (
+          <>
+            <div>
+              <label
+                htmlFor="submit-title"
+                className="block text-sm font-semibold text-[var(--text-1)] mb-2"
+              >
+                Title
+              </label>
+              <input
+                id="submit-title"
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Article title..."
+                disabled={loading}
+                className="w-full px-4 py-3 bg-[var(--bg-main)] text-[var(--text-1)] placeholder:text-[var(--text-3)] border-[var(--border-w)] border-[var(--border-color)] rounded-[var(--radius)] shadow-[var(--shadow-sm)] text-sm focus:outline-none focus:border-[var(--primary)] transition-colors disabled:opacity-50"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="submit-text"
+                className="block text-sm font-semibold text-[var(--text-1)] mb-2"
+              >
+                Content
+              </label>
+              <textarea
+                id="submit-text"
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                placeholder="Paste your article text here..."
+                rows={10}
+                disabled={loading}
+                className="w-full px-4 py-3 bg-[var(--bg-main)] text-[var(--text-1)] placeholder:text-[var(--text-3)] border-[var(--border-w)] border-[var(--border-color)] rounded-[var(--radius)] shadow-[var(--shadow-sm)] text-sm focus:outline-none focus:border-[var(--primary)] transition-colors resize-y disabled:opacity-50"
+              />
+              <p className="text-xs text-[var(--text-3)] mt-1">
+                Minimum 100 characters
+              </p>
+            </div>
+          </>
+        )}
+
+        {/* Submit button */}
+        <button
+          type="submit"
+          disabled={loading || success !== null}
+          className="nb-hover w-full flex items-center justify-center gap-2 px-6 py-3 bg-[var(--primary)] text-[var(--primary-text)] font-bold text-sm border-[var(--border-w)] border-[var(--border-color)] rounded-[var(--radius)] shadow-[var(--shadow-sm)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+        >
+          {loading ? (
+            <>
+              <Loader2 size={18} className="animate-spin" />
+              Generating podcast...
+            </>
+          ) : success ? (
+            <>
+              <CheckCircle2 size={18} />
+              Podcast queued
+            </>
+          ) : (
+            <>
+              <Headphones size={18} />
+              Podcastify
+            </>
+          )}
+        </button>
+
+        {/* Submit another */}
+        {success && (
+          <button
+            type="button"
+            onClick={resetForm}
+            className="w-full text-center text-sm text-[var(--text-2)] hover:text-[var(--text-1)] transition-colors cursor-pointer"
+          >
+            Submit another article
+          </button>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { PaginatedPosts, PostDetail, Tag, Source, CrawlStatusItem, Job } from "./types";
+import type { PaginatedPosts, PostDetail, Tag, Source, CrawlStatusItem, Job, SubmitResponse } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
@@ -176,6 +176,13 @@ export function getJobs(params: { job_type?: string; status?: string } = {}): Pr
   });
   const qs = searchParams.toString();
   return fetchAPI<Job[]>(`/api/jobs${qs ? `?${qs}` : ""}`);
+}
+
+export function submitPost(data: { url?: string; text?: string; title?: string }): Promise<SubmitResponse> {
+  return fetchAPI<SubmitResponse>("/api/posts/submit", {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
 }
 
 export function getAudioUrl(audioPath: string): string {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -57,6 +57,12 @@ export interface Job {
   completed_at: string | null;
 }
 
+export interface SubmitResponse {
+  post_id: number;
+  job_id: number;
+  status: string;
+}
+
 export interface CrawlStatusItem {
   source_key: string;
   source_name: string;


### PR DESCRIPTION
## Summary
- Adds `/submit` page with a **Podcastify** UI that lets users submit any URL or paste article text to generate a podcast
- `SubmitForm` component with URL/text tab switcher, client-side validation, loading spinner, success link, and error banner
- Wires up `submitPost()` API client to `POST /api/posts/submit` (merged in PR #132)
- Adds "Submit" nav item (PlusCircle icon) to both Sidebar and BottomTabs

Closes #126

## Test plan
- [ ] Navigate to `/submit` via sidebar or bottom tabs
- [ ] Submit a valid URL — verify queued success message and "View post" link
- [ ] Submit invalid URL — verify client-side validation error
- [ ] Switch to "Paste Text" tab — submit with title + text (100+ chars)
- [ ] Verify loading state shows spinner + "Generating podcast..."
- [ ] Verify "Submit another article" resets form after success
- [ ] `npm run build` and `npm run lint` pass with zero errors